### PR TITLE
Add deterministic claim extraction pipeline with sample data

### DIFF
--- a/infra/initdb/010_seed_sample_content.sql
+++ b/infra/initdb/010_seed_sample_content.sql
@@ -1,0 +1,75 @@
+-- Sample podcast, episodes, transcripts, and claims for development/testing.
+
+INSERT INTO podcast (id, title, description)
+VALUES
+    (1, 'Metabolic Morning Show', 'A fictional wellness podcast used for integration testing')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO podcast (id, title, description)
+VALUES
+    (2, 'Brain and Body Chat', 'Another fictional show for sample data')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO episode (id, podcast_id, title, description, published_at, duration_sec)
+VALUES
+    (1, 1, 'Metabolic Morning Show 001', 'Metabolic routines for morning energy', '2024-01-05', 1800),
+    (2, 1, 'Metabolic Morning Show 002', 'Cold exposure and training insights', '2024-01-12', 1900),
+    (3, 2, 'Brain and Body Chat 015', 'Nutrition and sleep tactics for cognition', '2024-01-19', 2000)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO transcript (id, episode_id, source, lang, text, word_count, has_verbatim_ok)
+VALUES
+    (1, 1, 'synthetic', 'en', 'This morning show host explains that keeping blood sugar stable reduces afternoon crashes. He says a consistent overnight fast of fourteen hours raises ketone production and supports morning focus. She claims that drinking mineral water with sodium prevents headaches during fasting. He notes research showing that a protein rich breakfast lowers cravings for sugary snacks. They discuss how a quick walk in daylight improves sleep onset that night. The guest argues that limiting blue light after sunset increases melatonin and sleep depth. The host states that practicing box breathing for five minutes decreases cortisol levels. She adds that adding a tablespoon of ground flaxseed daily improves digestion. He mentions that consistent bed times calibrate the circadian rhythm. They assert that journaling gratitude each evening reduces perceived stress. She reports that replacing afternoon coffee with herbal tea reduces evening anxiety. Finally he says that using a cool bedroom around sixty five degrees improves sleep quality.', 154, TRUE),
+    (2, 2, 'synthetic', 'en', 'The host asserts that a ten minute cold shower boosts norepinephrine for hours. He states that moderate cold exposure three times per week increases brown fat activity. She explains that combining cold plunges with breathing exercises accelerates recovery after workouts. The guest says that eating salmon twice a week raises omega three levels that support heart health. He claims that omega three fats reduce inflammation markers in endurance athletes. She adds that supplementing creatine improves power output during sprint training. He notes that creatine supplementation also supports cognitive resilience during sleep deprivation. They mention that pairing creatine with carbohydrates enhances uptake into muscle cells. The host comments that practicing mindfulness before training lowers perceived exertion. She says that stretching hips daily reduces lower back pain in runners. He adds that rotating running shoes decreases injury risk. They conclude that going to bed before midnight improves hormone regulation. Finally he remarks that cold exposure combined with fasting keeps ketone levels elevated.', 160, TRUE),
+    (3, 3, 'synthetic', 'en', 'The neuroscientist guest claims that maintaining steady ketone availability fuels brain metabolism when glucose dips. She states that exogenous ketone drinks can enhance mental endurance during long study sessions. He says that periodic fasting improves insulin sensitivity in middle aged adults. The host notes that pairing fasting with light exercise increases fat oxidation. She observes that consuming fermented vegetables daily supports gut microbiome diversity. He mentions that probiotics reduce the frequency of seasonal colds. They suggest that adequate hydration before workouts prevents dizziness. The guest remarks that magnesium glycinate before bed improves sleep efficiency. He adds that dimming lights an hour before bed lowers evening cortisol. She claims that listening to calming music before sleep shortens sleep latency. He warns that scrolling on phones at night delays melatonin release. They finish by saying that consistent wake times strengthen circadian alignment.', 140, TRUE)
+ON CONFLICT (id) DO NOTHING;
+
+-- Claims for episode 1
+INSERT INTO claim (id, episode_id, start_ms, end_ms, raw_text, normalized_text, topic, domain, risk_level)
+VALUES
+    (1, 1, 0, 6500, 'The speaker maintains that this morning show host explains that keeping blood sugar stable lowers afternoon crashes.', 'the speaker maintains that this morning show host explains that keeping blood sugar stable lowers afternoon crashes', 'general_health', 'wellness', 'medium'),
+    (2, 1, 6500, 14500, 'The speaker maintains that a consistent overnight fast of fourteen hours raises ketone production and supports morning focus.', 'the speaker maintains that a consistent overnight fast of fourteen hours raises ketone production and supports morning focus', 'ketones', 'metabolism', 'medium'),
+    (3, 1, 14500, 20500, 'The speaker maintains that drinking mineral water with sodium avoids headaches during fasting.', 'the speaker maintains that drinking mineral water with sodium avoids headaches during fasting', 'intermittent_fasting', 'nutrition', 'medium'),
+    (4, 1, 20500, 27500, 'The speaker maintains that research showing that a protein rich breakfast lowers cravings for sugary snacks.', 'the speaker maintains that research showing that a protein rich breakfast lowers cravings for sugary snacks', 'intermittent_fasting', 'nutrition', 'medium'),
+    (5, 1, 27500, 34000, 'The speaker maintains that they discuss how a quick walk in daylight enhances sleep onset that night.', 'the speaker maintains that they discuss how a quick walk in daylight enhances sleep onset that night', 'sleep_quality', 'wellness', 'medium'),
+    (6, 1, 34000, 41000, 'The speaker maintains that limiting blue light after sunset raises melatonin and sleep depth.', 'the speaker maintains that limiting blue light after sunset raises melatonin and sleep depth', 'sleep_quality', 'wellness', 'medium'),
+    (7, 1, 41000, 47500, 'The speaker maintains that practicing box breathing for five minutes lowers cortisol levels.', 'the speaker maintains that practicing box breathing for five minutes lowers cortisol levels', 'stress_hormones', 'endocrinology', 'medium'),
+    (8, 1, 47500, 53500, 'The speaker maintains that adding a tablespoon of ground flaxseed daily enhances digestion.', 'the speaker maintains that adding a tablespoon of ground flaxseed daily enhances digestion', 'general_health', 'wellness', 'medium'),
+    (9, 1, 58500, 63500, 'The speaker maintains that journaling gratitude each evening lowers perceived stress.', 'the speaker maintains that journaling gratitude each evening lowers perceived stress', 'general_health', 'wellness', 'medium'),
+    (10, 1, 63500, 69500, 'The speaker maintains that replacing afternoon coffee with herbal tea lowers evening anxiety.', 'the speaker maintains that replacing afternoon coffee with herbal tea lowers evening anxiety', 'general_health', 'wellness', 'medium'),
+    (11, 1, 69500, 77000, 'The speaker maintains that using a cool bedroom around sixty five degrees enhances sleep quality.', 'the speaker maintains that using a cool bedroom around sixty five degrees enhances sleep quality', 'sleep_quality', 'wellness', 'medium')
+ON CONFLICT (id) DO NOTHING;
+
+-- Claims for episode 2
+INSERT INTO claim (id, episode_id, start_ms, end_ms, raw_text, normalized_text, topic, domain, risk_level)
+VALUES
+    (12, 2, 0, 6500, 'The speaker maintains that a ten minute cold shower elevates norepinephrine for hours.', 'the speaker maintains that a ten minute cold shower elevates norepinephrine for hours', 'norepinephrine', 'neurochemistry', 'medium'),
+    (13, 2, 6500, 13500, 'The speaker maintains that moderate cold exposure three times per week raises brown fat activity.', 'the speaker maintains that moderate cold exposure three times per week raises brown fat activity', 'brown_adipose_tissue', 'metabolism', 'medium'),
+    (14, 2, 13500, 20000, 'The speaker maintains that combining cold plunges with breathing exercises accelerates recovery after workouts.', 'the speaker maintains that combining cold plunges with breathing exercises accelerates recovery after workouts', 'general_health', 'wellness', 'medium'),
+    (15, 2, 20000, 28500, 'The speaker maintains that eating salmon twice a week raises omega three levels that supports heart health.', 'the speaker maintains that eating salmon twice a week raises omega three levels that supports heart health', 'omega_3', 'nutrition', 'medium'),
+    (16, 2, 28500, 34500, 'The speaker maintains that omega three fats lowers inflammation markers in endurance athletes.', 'the speaker maintains that omega three fats lowers inflammation markers in endurance athletes', 'omega_3', 'nutrition', 'medium'),
+    (17, 2, 34500, 40000, 'The speaker maintains that supplementing creatine enhances power output during sprint training.', 'the speaker maintains that supplementing creatine enhances power output during sprint training', 'creatine', 'performance', 'medium'),
+    (18, 2, 40000, 46000, 'The speaker maintains that creatine supplementation also supports cognitive resilience during sleep deprivation.', 'the speaker maintains that creatine supplementation also supports cognitive resilience during sleep deprivation', 'sleep_quality', 'wellness', 'medium'),
+    (19, 2, 46000, 52000, 'The speaker maintains that pairing creatine with carbohydrates enhances uptake into muscle cells.', 'the speaker maintains that pairing creatine with carbohydrates enhances uptake into muscle cells', 'creatine', 'performance', 'medium'),
+    (20, 2, 52000, 57500, 'The speaker maintains that practicing mindfulness before training lowers perceived exertion.', 'the speaker maintains that practicing mindfulness before training lowers perceived exertion', 'general_health', 'wellness', 'medium'),
+    (21, 2, 57500, 63500, 'The speaker maintains that stretching hips daily lowers lower back pain in runners.', 'the speaker maintains that stretching hips daily lowers lower back pain in runners', 'general_health', 'wellness', 'medium'),
+    (22, 2, 63500, 68000, 'The speaker maintains that rotating running shoes lowers injury risk.', 'the speaker maintains that rotating running shoes lowers injury risk', 'general_health', 'wellness', 'medium'),
+    (23, 2, 68000, 73500, 'The speaker maintains that going to bed before midnight enhances hormone regulation.', 'the speaker maintains that going to bed before midnight enhances hormone regulation', 'general_health', 'wellness', 'medium')
+ON CONFLICT (id) DO NOTHING;
+
+-- Claims for episode 3
+INSERT INTO claim (id, episode_id, start_ms, end_ms, raw_text, normalized_text, topic, domain, risk_level)
+VALUES
+    (24, 3, 0, 7500, 'The speaker maintains that the neuroscientist guest claims that maintaining steady ketone availability fuels brain metabolism when glucose dips.', 'the speaker maintains that the neuroscientist guest claims that maintaining steady ketone availability fuels brain metabolism when glucose dips', 'ketones', 'metabolism', 'medium'),
+    (25, 3, 7500, 14500, 'The speaker maintains that exogenous ketone drinks can enhance mental endurance during long study sessions.', 'the speaker maintains that exogenous ketone drinks can enhance mental endurance during long study sessions', 'ketones', 'metabolism', 'medium'),
+    (26, 3, 14500, 20500, 'The speaker maintains that periodic fasting enhances insulin sensitivity in middle aged adults.', 'the speaker maintains that periodic fasting enhances insulin sensitivity in middle aged adults', 'intermittent_fasting', 'nutrition', 'medium'),
+    (27, 3, 20500, 26500, 'The speaker maintains that pairing fasting with light exercise raises fat oxidation.', 'the speaker maintains that pairing fasting with light exercise raises fat oxidation', 'intermittent_fasting', 'nutrition', 'medium'),
+    (28, 3, 26500, 32000, 'The speaker maintains that consuming fermented vegetables daily supports gut microbiome diversity.', 'the speaker maintains that consuming fermented vegetables daily supports gut microbiome diversity', 'gut_microbiome', 'nutrition', 'medium'),
+    (29, 3, 32000, 37000, 'The speaker maintains that probiotics lowers the frequency of seasonal colds.', 'the speaker maintains that probiotics lowers the frequency of seasonal colds', 'probiotics', 'nutrition', 'medium'),
+    (30, 3, 37000, 41500, 'The speaker maintains that adequate hydration before workouts avoids dizziness.', 'the speaker maintains that adequate hydration before workouts avoids dizziness', 'hydration', 'performance', 'medium'),
+    (31, 3, 41500, 47000, 'The speaker maintains that the guest remarks that magnesium glycinate before bed enhances sleep efficiency.', 'the speaker maintains that the guest remarks that magnesium glycinate before bed enhances sleep efficiency', 'sleep_quality', 'wellness', 'medium'),
+    (32, 3, 47000, 53000, 'The speaker maintains that dimming lights an hour before bed lowers evening cortisol.', 'the speaker maintains that dimming lights an hour before bed lowers evening cortisol', 'stress_hormones', 'endocrinology', 'medium'),
+    (33, 3, 53000, 59000, 'The speaker maintains that listening to calming music before sleep shortens sleep latency.', 'the speaker maintains that listening to calming music before sleep shortens sleep latency', 'sleep_quality', 'wellness', 'medium'),
+    (34, 3, 64500, 70000, 'The speaker maintains that they finish by saying that consistent wake times strengthen circadian alignment.', 'the speaker maintains that they finish by saying that consistent wake times strengthen circadian alignment', 'circadian_rhythm', 'sleep', 'medium')
+ON CONFLICT (id) DO NOTHING;
+

--- a/tests/data/sample_transcripts.json
+++ b/tests/data/sample_transcripts.json
@@ -1,0 +1,19 @@
+{
+  "episodes": [
+    {
+      "id": 1,
+      "title": "Metabolic Morning Show 001",
+      "transcript": "This morning show host explains that keeping blood sugar stable reduces afternoon crashes. He says a consistent overnight fast of fourteen hours raises ketone production and supports morning focus. She claims that drinking mineral water with sodium prevents headaches during fasting. He notes research showing that a protein rich breakfast lowers cravings for sugary snacks. They discuss how a quick walk in daylight improves sleep onset that night. The guest argues that limiting blue light after sunset increases melatonin and sleep depth. The host states that practicing box breathing for five minutes decreases cortisol levels. She adds that adding a tablespoon of ground flaxseed daily improves digestion. He mentions that consistent bed times calibrate the circadian rhythm. They assert that journaling gratitude each evening reduces perceived stress. She reports that replacing afternoon coffee with herbal tea reduces evening anxiety. Finally he says that using a cool bedroom around sixty five degrees improves sleep quality."
+    },
+    {
+      "id": 2,
+      "title": "Metabolic Morning Show 002",
+      "transcript": "The host asserts that a ten minute cold shower boosts norepinephrine for hours. He states that moderate cold exposure three times per week increases brown fat activity. She explains that combining cold plunges with breathing exercises accelerates recovery after workouts. The guest says that eating salmon twice a week raises omega three levels that support heart health. He claims that omega three fats reduce inflammation markers in endurance athletes. She adds that supplementing creatine improves power output during sprint training. He notes that creatine supplementation also supports cognitive resilience during sleep deprivation. They mention that pairing creatine with carbohydrates enhances uptake into muscle cells. The host comments that practicing mindfulness before training lowers perceived exertion. She says that stretching hips daily reduces lower back pain in runners. He adds that rotating running shoes decreases injury risk. They conclude that going to bed before midnight improves hormone regulation. Finally he remarks that cold exposure combined with fasting keeps ketone levels elevated."
+    },
+    {
+      "id": 3,
+      "title": "Brain and Body Chat 015",
+      "transcript": "The neuroscientist guest claims that maintaining steady ketone availability fuels brain metabolism when glucose dips. She states that exogenous ketone drinks can enhance mental endurance during long study sessions. He says that periodic fasting improves insulin sensitivity in middle aged adults. The host notes that pairing fasting with light exercise increases fat oxidation. She observes that consuming fermented vegetables daily supports gut microbiome diversity. He mentions that probiotics reduce the frequency of seasonal colds. They suggest that adequate hydration before workouts prevents dizziness. The guest remarks that magnesium glycinate before bed improves sleep efficiency. He adds that dimming lights an hour before bed lowers evening cortisol. She claims that listening to calming music before sleep shortens sleep latency. He warns that scrolling on phones at night delays melatonin release. They finish by saying that consistent wake times strengthen circadian alignment."
+    }
+  ]
+}

--- a/tests/test_claim_extraction.py
+++ b/tests/test_claim_extraction.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from worker.claim_extraction import (
+    SEGMENT_MAX_MS,
+    SEGMENT_MIN_MS,
+    build_segments,
+    extract_claims,
+    iter_sentences,
+)
+
+
+@pytest.fixture(scope="module")
+def sample_episodes():
+    data_path = Path(__file__).parent / "data" / "sample_transcripts.json"
+    with data_path.open() as fh:
+        return json.load(fh)["episodes"]
+
+
+def test_each_episode_has_claims(sample_episodes):
+    for episode in sample_episodes:
+        claims = extract_claims(episode["transcript"])
+        assert len(claims) >= 5
+
+        normalized = [claim.normalized_text for claim in claims]
+        assert len(set(normalized)) == len(normalized)
+        assert all(claim.start_ms < claim.end_ms for claim in claims)
+
+
+def test_topics_overlap_across_episodes(sample_episodes):
+    topic_map: dict[str, set[int]] = {}
+    for idx, episode in enumerate(sample_episodes):
+        for claim in extract_claims(episode["transcript"]):
+            topic_map.setdefault(claim.topic, set()).add(idx)
+
+    overlapping = [episodes for episodes in topic_map.values() if len(episodes) >= 2]
+    assert overlapping, "expected at least one topic to appear in multiple episodes"
+
+
+def test_segment_duration_bounds(sample_episodes):
+    # Use the first episode as a representative sample
+    episode = sample_episodes[0]
+    sentences = iter_sentences(episode["transcript"])
+    segments = build_segments(sentences)
+    assert segments, "segments should not be empty"
+
+    for idx, segment in enumerate(segments):
+        duration = segment.end_ms - segment.start_ms
+        assert duration <= SEGMENT_MAX_MS
+        if idx < len(segments) - 1:
+            assert duration >= SEGMENT_MIN_MS
+

--- a/worker/__init__.py
+++ b/worker/__init__.py
@@ -1,0 +1,5 @@
+"""Worker package exposing helper utilities for background jobs."""
+
+from .claim_extraction import Claim, Segment, extract_claims
+
+__all__ = ["Claim", "Segment", "extract_claims"]

--- a/worker/claim_extraction.py
+++ b/worker/claim_extraction.py
@@ -1,0 +1,407 @@
+"""Utility functions for extracting structured claims from transcripts.
+
+This module provides a lightweight heuristic implementation that is good
+enough for bootstrapping an early claim extraction pipeline.  The focus is on
+creating deterministic, testable behaviour rather than sophisticated natural
+language understanding.
+
+The extractor works in a couple of steps:
+
+1.  Split the transcript into sentences and estimate timestamps using a
+    constant words-per-minute assumption.  We then group the sentences into
+    20–40 second segments.  Segments are useful for downstream systems (e.g.
+    snippets or manual review) even if, for the purposes of this milestone,
+    claims are derived at the sentence level.
+2.  Filter sentences with a list of "claim verbs".  These verbs represent
+    action-oriented statements that can be fact-checked (e.g. *improves* or
+    *reduces*).  Anecdotal language such as "I remember" is ignored.
+3.  Paraphrase the sentence by stripping filler phrases ("the guest says
+    that"), applying a small synonym map, and wrapping it in a deterministic
+    template ("The speaker maintains that …").
+4.  Normalise the paraphrase so that we can deduplicate claims within an
+    episode and provide a canonical form for search.
+5.  Assign topic/domain labels and a risk estimate using keyword lookups.
+
+The output of the extractor is a list of :class:`Claim` instances ready to be
+inserted into the database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Sequence, Tuple
+
+
+# Speech rate assumption used for timestamp estimation.  120 wpm keeps the
+# resulting segments within the 20–40 second window for typical paragraph
+# lengths in our sample data.
+WORDS_PER_MINUTE = 120
+MS_PER_WORD = int(round(60_000 / WORDS_PER_MINUTE))
+
+# Segmentation parameters (20–40 seconds)
+SEGMENT_MIN_MS = 20_000
+SEGMENT_MAX_MS = 40_000
+SEGMENT_TARGET_MS = 30_000
+
+# Key verbs indicating that a sentence is making a checkable assertion.
+CLAIM_VERBS = {
+    "increase",
+    "improve",
+    "reduce",
+    "prevent",
+    "support",
+    "boost",
+    "raise",
+    "lower",
+    "enhance",
+    "maintain",
+    "decrease",
+    "assist",
+    "protect",
+    "strengthen",
+    "fuel",
+    "accelerate",
+    "help",
+    "shorten",
+    "stabilize",
+}
+
+# Words/phrases that suggest the sentence is anecdotal rather than a testable
+# claim.  We skip sentences that contain any of these tokens.
+ANECDOTE_MARKERS = {
+    "i remember",
+    "i once",
+    "i used to",
+    "story",
+    "my friend",
+    "i feel",
+    "i think",
+}
+
+# Mapping of keyword -> (topic, domain)
+TOPIC_KEYWORDS: List[Tuple[str, str, str]] = [
+    ("ketone", "ketones", "metabolism"),
+    ("fast", "intermittent_fasting", "nutrition"),
+    ("sleep", "sleep_quality", "wellness"),
+    ("melatonin", "melatonin", "sleep"),
+    ("circadian", "circadian_rhythm", "sleep"),
+    ("cortisol", "stress_hormones", "endocrinology"),
+    ("omega", "omega_3", "nutrition"),
+    ("creatine", "creatine", "performance"),
+    ("brown fat", "brown_adipose_tissue", "metabolism"),
+    ("norepinephrine", "norepinephrine", "neurochemistry"),
+    ("hydration", "hydration", "performance"),
+    ("magnesium", "magnesium", "supplements"),
+    ("microbiome", "gut_microbiome", "nutrition"),
+    ("fermented", "fermented_foods", "nutrition"),
+    ("probiotic", "probiotics", "nutrition"),
+    ("glucose", "glucose_regulation", "metabolism"),
+]
+
+# Replacement pairs used to create simple paraphrases.  The replacements are
+# case-insensitive and preserve deterministic wording.
+PARAPHRASE_REPLACEMENTS: Sequence[Tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bboosts?\b", re.I), "elevates"),
+    (re.compile(r"\bimproves?\b", re.I), "enhances"),
+    (re.compile(r"\bincreases?\b", re.I), "raises"),
+    (re.compile(r"\braises?\b", re.I), "raises"),
+    (re.compile(r"\breduces?\b", re.I), "lowers"),
+    (re.compile(r"\bdecreases?\b", re.I), "lowers"),
+    (re.compile(r"\bhelps?\b", re.I), "assists"),
+    (re.compile(r"\bsupports?\b", re.I), "supports"),
+    (re.compile(r"\bprevents?\b", re.I), "avoids"),
+    (re.compile(r"\bmaintains?\b", re.I), "maintains"),
+    (re.compile(r"\bfuels?\b", re.I), "fuels"),
+    (re.compile(r"\bprotects?\b", re.I), "protects"),
+    (re.compile(r"\bshortens?\b", re.I), "shortens"),
+]
+
+
+@dataclass(frozen=True)
+class Sentence:
+    """A sentence with estimated timing metadata."""
+
+    text: str
+    start_word: int
+    end_word: int
+    start_ms: int
+    end_ms: int
+
+
+@dataclass(frozen=True)
+class Segment:
+    """A contiguous block of sentences roughly 20–40 seconds long."""
+
+    text: str
+    start_ms: int
+    end_ms: int
+
+
+@dataclass(frozen=True)
+class Claim:
+    """Structured claim data ready for persistence."""
+
+    raw_text: str
+    normalized_text: str
+    topic: str
+    domain: str
+    risk_level: str
+    start_ms: int
+    end_ms: int
+
+
+WORD_RE = re.compile(r"\b[\w']+\b")
+SENTENCE_RE = re.compile(r"[^.!?]+[.!?]")
+
+
+def iter_sentences(text: str) -> List[Sentence]:
+    """Split *text* into sentences with approximate timing metadata."""
+
+    tokens = list(WORD_RE.finditer(text))
+    ms_per_word = MS_PER_WORD
+    sentences: List[Sentence] = []
+
+    if not tokens:
+        return sentences
+
+    token_index = 0
+    for match in SENTENCE_RE.finditer(text):
+        sentence_text = match.group().strip()
+        start_char, end_char = match.span()
+
+        # Advance to the first token that belongs to this sentence.
+        while token_index < len(tokens) and tokens[token_index].end() <= start_char:
+            token_index += 1
+        start_word = token_index
+
+        # Consume tokens contained in this sentence.
+        while token_index < len(tokens) and tokens[token_index].start() < end_char:
+            token_index += 1
+        end_word = token_index
+
+        if start_word == end_word:
+            continue
+
+        start_ms = start_word * ms_per_word
+        end_ms = max(start_ms + ms_per_word, end_word * ms_per_word)
+        sentences.append(
+            Sentence(
+                text=sentence_text,
+                start_word=start_word,
+                end_word=end_word,
+                start_ms=start_ms,
+                end_ms=end_ms,
+            )
+        )
+
+    return sentences
+
+
+def build_segments(sentences: Sequence[Sentence]) -> List[Segment]:
+    """Group sentences into ~30s segments."""
+
+    segments: List[Segment] = []
+    if not sentences:
+        return segments
+
+    current: List[Sentence] = []
+    seg_start_ms = sentences[0].start_ms
+
+    for sentence in sentences:
+        if not current:
+            seg_start_ms = sentence.start_ms
+        current.append(sentence)
+        seg_end_ms = current[-1].end_ms
+        duration = seg_end_ms - seg_start_ms
+
+        should_close = False
+        if duration >= SEGMENT_TARGET_MS:
+            should_close = True
+        elif duration >= SEGMENT_MIN_MS and len(current) >= 3:
+            should_close = True
+
+        if should_close:
+            segments.append(
+                Segment(
+                    text=" ".join(s.text.strip() for s in current),
+                    start_ms=seg_start_ms,
+                    end_ms=seg_end_ms,
+                )
+            )
+            current = []
+
+    if current:
+        segments.append(
+            Segment(
+                text=" ".join(s.text.strip() for s in current),
+                start_ms=current[0].start_ms,
+                end_ms=current[-1].end_ms,
+            )
+        )
+
+    # Ensure final durations do not exceed the upper bound by splitting if
+    # required.  This keeps the behaviour deterministic for testing.
+    normalised_segments: List[Segment] = []
+    for seg in segments:
+        if seg.end_ms - seg.start_ms <= SEGMENT_MAX_MS or " " not in seg.text:
+            normalised_segments.append(seg)
+            continue
+
+        sentence_texts = seg.text.split(". ")
+        running_start = seg.start_ms
+        for piece in sentence_texts:
+            piece = piece.strip()
+            if not piece:
+                continue
+            approx_words = len(piece.split())
+            piece_duration = max(SEGMENT_MIN_MS, approx_words * MS_PER_WORD)
+            running_end = min(running_start + piece_duration, seg.end_ms)
+            normalised_segments.append(
+                Segment(text=piece + ("." if not piece.endswith(".") else ""), start_ms=running_start, end_ms=running_end)
+            )
+            running_start = running_end
+
+    return normalised_segments
+
+
+def _looks_like_claim(sentence: Sentence) -> bool:
+    lowered = sentence.text.lower()
+    if any(marker in lowered for marker in ANECDOTE_MARKERS):
+        return False
+    return any(verb in lowered for verb in CLAIM_VERBS)
+
+
+_LEADING_PHRASE = re.compile(
+    r"^(?:(?:finally|additionally|overall|then|next|lastly)\s+)?"
+    r"(?:(?:the\s+(?:host|guest|speaker|discussion))|(?:he|she|they|we))\s+"
+    r"(?:(?:\w+\s+){0,2})?(?:states?|says?|notes?|mentions?|adds?|explains?|argues?|asserts?|comments?|observes?|reports?|believes|claims?|warns?|suggests?|emphasises?|concludes?)\s+"
+    r"(?:that\s+)?",
+    re.I,
+)
+
+
+def paraphrase(sentence: str) -> str:
+    """Create a deterministic paraphrase of *sentence*."""
+
+    text = sentence.strip()
+    # Remove leading filler phrases ("The host says that ...").
+    while True:
+        new_text = _LEADING_PHRASE.sub("", text)
+        if new_text == text:
+            break
+        text = new_text.strip()
+
+    # Remove stray leading "that" produced by aggressive stripping.
+    text = re.sub(r"^that\s+", "", text, flags=re.I)
+
+    for pattern, replacement in PARAPHRASE_REPLACEMENTS:
+        text = pattern.sub(replacement, text)
+
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return ""
+
+    if not text.endswith(('.', '!', '?')):
+        text = f"{text}."
+
+    core = text[0].lower() + text[1:] if len(text) > 1 else text.lower()
+    return f"The speaker maintains that {core}"
+
+
+def normalise(text: str) -> str:
+    lowered = text.lower()
+    lowered = re.sub(r"[^a-z0-9\s]", "", lowered)
+    lowered = re.sub(r"\s+", " ", lowered)
+    return lowered.strip()
+
+
+def choose_topic_domain(normalized_text: str) -> Tuple[str, str]:
+    for keyword, topic, domain in TOPIC_KEYWORDS:
+        if keyword in normalized_text:
+            return topic, domain
+    return "general_health", "wellness"
+
+
+def estimate_risk_level(normalized_text: str) -> str:
+    if re.search(r"\b(?:cures?|eliminates|guarantees)\b", normalized_text):
+        return "high"
+    if re.search(r"\b(?:may|might|could|suggests?)\b", normalized_text):
+        return "low"
+    if re.search(r"\b(?:reduces?|lowers?|decreases?|improves?|enhances?|raises?|increases?)\b", normalized_text):
+        return "medium"
+    return "medium"
+
+
+def extract_claims(text: str) -> List[Claim]:
+    """Extract deterministic claims from *text*."""
+
+    sentences = iter_sentences(text)
+    segments = build_segments(sentences)
+
+    claims: List[Claim] = []
+    seen: set[str] = set()
+
+    for sentence in sentences:
+        if not _looks_like_claim(sentence):
+            continue
+
+        raw = paraphrase(sentence.text)
+        if not raw:
+            continue
+
+        normalized = normalise(raw)
+        if not normalized or normalized in seen:
+            continue
+
+        topic, domain = choose_topic_domain(normalized)
+        risk = estimate_risk_level(normalized)
+
+        claims.append(
+            Claim(
+                raw_text=raw,
+                normalized_text=normalized,
+                topic=topic,
+                domain=domain,
+                risk_level=risk,
+                start_ms=sentence.start_ms,
+                end_ms=sentence.end_ms,
+            )
+        )
+        seen.add(normalized)
+
+    # Ensure claims inherit segment boundaries if the estimated sentence times
+    # happen to be zero-length (e.g., very short sentences).  We match the
+    # sentence to the segment it belongs to.
+    if segments:
+        for idx, claim in enumerate(claims):
+            for segment in segments:
+                if segment.start_ms <= claim.start_ms < segment.end_ms:
+                    if claim.end_ms < segment.start_ms:
+                        continue
+                    if claim.end_ms > segment.end_ms:
+                        claim_end = segment.end_ms
+                    else:
+                        claim_end = claim.end_ms
+                    claims[idx] = Claim(
+                        raw_text=claim.raw_text,
+                        normalized_text=claim.normalized_text,
+                        topic=claim.topic,
+                        domain=claim.domain,
+                        risk_level=claim.risk_level,
+                        start_ms=max(segment.start_ms, claim.start_ms),
+                        end_ms=claim_end,
+                    )
+                    break
+
+    return claims
+
+
+def extract_claims_from_segments(segments: Iterable[Segment]) -> List[Claim]:
+    """Convenience helper to process already segmented transcripts."""
+
+    claims: List[Claim] = []
+    for segment in segments:
+        claims.extend(extract_claims(segment.text))
+    return claims
+

--- a/worker/claim_pipeline.py
+++ b/worker/claim_pipeline.py
@@ -1,0 +1,100 @@
+"""Command line helper for running the claim extraction pipeline.
+
+This script connects to the database, reads transcripts, extracts claims using
+the heuristics in :mod:`worker.claim_extraction`, and inserts (or replaces)
+claim rows for each episode.  It is intentionally simple so that it can be run
+manually during the milestone without introducing a full task queue.
+
+Usage::
+
+    DATABASE_URL=postgresql://postgres:postgres@localhost:5432/podcast_plow \
+        python -m worker.claim_pipeline
+
+Optional arguments:
+
+``--episode``
+    Limit extraction to a single episode id.  The default processes every
+    transcript currently stored in the database.
+
+The script deletes existing claims for the episode before inserting new ones so
+that repeated runs stay idempotent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Iterable, List
+
+import psycopg
+
+from .claim_extraction import Claim, extract_claims
+
+
+def fetch_transcripts(conn, episode_id: int | None = None) -> Iterable[tuple[int, int, str]]:
+    """Yield ``(transcript_id, episode_id, text)`` tuples from the database."""
+
+    with conn.cursor() as cur:
+        if episode_id is None:
+            cur.execute("SELECT id, episode_id, text FROM transcript")
+        else:
+            cur.execute(
+                "SELECT id, episode_id, text FROM transcript WHERE episode_id = %s",
+                (episode_id,),
+            )
+        for row in cur:
+            yield row[0], row[1], row[2]
+
+
+def replace_claims(conn, episode_id: int, claims: List[Claim]) -> None:
+    """Replace all claims for an episode with ``claims``."""
+
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM claim WHERE episode_id = %s", (episode_id,))
+        for claim in claims:
+            cur.execute(
+                """
+                INSERT INTO claim (episode_id, start_ms, end_ms, raw_text, normalized_text, topic, domain, risk_level)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    episode_id,
+                    claim.start_ms,
+                    claim.end_ms,
+                    claim.raw_text,
+                    claim.normalized_text,
+                    claim.topic,
+                    claim.domain,
+                    claim.risk_level,
+                ),
+            )
+
+
+def run(episode_id: int | None = None) -> int:
+    database_url = os.getenv(
+        "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/podcast_plow"
+    )
+    with psycopg.connect(database_url, autocommit=True) as conn:
+        processed = 0
+        for _, e_id, text in fetch_transcripts(conn, episode_id=episode_id):
+            claims = extract_claims(text or "")
+            replace_claims(conn, e_id, claims)
+            processed += 1
+    return processed
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Extract claims from transcripts")
+    parser.add_argument(
+        "--episode",
+        type=int,
+        help="only process the specified episode id",
+    )
+    args = parser.parse_args(argv)
+    count = run(episode_id=args.episode)
+    print(f"processed {count} transcripts")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a deterministic claim extraction module that segments transcripts, paraphrases claim sentences, and assigns topics/domains
- provide a command line helper to run the pipeline against the database and replace episode claims
- seed sample podcasts, transcripts, and generated claims plus regression tests that exercise the extractor on representative episodes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15b33fcb483249a6421593b1b4e56