### PR TITLE
Implement automated claim grading workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Check health:
 curl http://localhost:8000/healthz
 ```
 
+Auto-grade all claims (creates versioned `claim_grade` rows):
+```
+python -m worker.auto_grade
+```
+
 Open API docs:
 - http://localhost:8000/docs
 - http://localhost:8000/redoc

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,2 @@
+"""Server package."""
+

--- a/server/app.py
+++ b/server/app.py
@@ -73,7 +73,7 @@ def get_topic_claims(topic: str):
                 FROM claim_grade
                 ORDER BY claim_id, created_at DESC
             )
-            SELECT c.id, e.id as episode_id, e.title, c.raw_text, c.normalized_text, c.domain, lg.grade
+            SELECT c.id, e.id as episode_id, e.title, c.raw_text, c.normalized_text, c.domain, lg.grade, lg.rationale
             FROM claim c
             JOIN episode e ON e.id = c.episode_id
             LEFT JOIN latest_grade lg ON lg.claim_id = c.id
@@ -90,6 +90,7 @@ def get_topic_claims(topic: str):
                 "normalized_text": r[4],
                 "domain": r[5],
                 "grade": r[6],
+                "grade_rationale": r[7],
             })
         return {"topic": topic, "claims": items}
 

--- a/server/core/grading.py
+++ b/server/core/grading.py
@@ -1,0 +1,136 @@
+"""Utilities for computing claim grades from linked evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+RUBRIC_VERSION = "auto-v1"
+AUTO_GRADED_BY = "auto-grader"
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    """Normalized representation of evidence used for grading."""
+
+    stance: str | None
+    type: str | None
+
+
+@dataclass(frozen=True)
+class ClaimEvidence:
+    """Container for a claim and its evidence rows."""
+
+    claim_id: int
+    evidence: Sequence[EvidenceItem]
+
+
+HIGH_KEYWORDS = {
+    "meta-analysis",
+    "systematic review",
+    "randomized controlled trial",
+    "randomized",
+    "double-blind",
+    "rct",
+}
+MEDIUM_KEYWORDS = {
+    "cohort",
+    "case-control",
+    "observational",
+    "clinical trial",
+    "pilot",
+    "survey",
+    "study",
+}
+LOW_KEYWORDS = {
+    "case report",
+    "case series",
+    "animal",
+    "mechanistic",
+    "in vitro",
+    "cell",
+    "expert opinion",
+}
+
+
+def _classify_evidence_strength(evidence_type: str | None) -> str:
+    """Return ``high``, ``medium``, or ``low`` for a textual type label."""
+
+    if not evidence_type:
+        return "low"
+
+    etype = evidence_type.strip().lower()
+    if not etype:
+        return "low"
+    if any(keyword in etype for keyword in HIGH_KEYWORDS):
+        return "high"
+    if any(keyword in etype for keyword in MEDIUM_KEYWORDS):
+        return "medium"
+    if any(keyword in etype for keyword in LOW_KEYWORDS):
+        return "low"
+    # default to medium quality when uncertain – better than unsupported but
+    # not as strong as a randomized/meta analysis.
+    return "medium"
+
+
+def compute_grade(evidence_items: Iterable[EvidenceItem]) -> tuple[str, str]:
+    """Compute a (grade, rationale) tuple for the provided evidence rows."""
+
+    support_counts = {"high": 0, "medium": 0, "low": 0}
+    refute_counts = {"high": 0, "medium": 0, "low": 0}
+
+    for item in evidence_items:
+        stance = (item.stance or "").strip().lower()
+        strength = _classify_evidence_strength(item.type)
+        if stance == "supports":
+            support_counts[strength] += 1
+        elif stance == "refutes":
+            refute_counts[strength] += 1
+
+    total_support = sum(support_counts.values())
+    total_refute = sum(refute_counts.values())
+
+    if total_support == 0:
+        grade = "unsupported"
+    else:
+        high = support_counts["high"]
+        medium = support_counts["medium"]
+        low = support_counts["low"]
+
+        if high >= 2 or (high >= 1 and (medium >= 1 or total_support >= 3)):
+            grade = "strong"
+        elif high >= 1 or medium >= 2:
+            grade = "moderate"
+        elif medium >= 1 or low >= 1:
+            grade = "weak"
+        else:
+            grade = "unsupported"
+
+    # conflicting evidence dampens confidence
+    grade_order = ["unsupported", "weak", "moderate", "strong"]
+    idx = grade_order.index(grade)
+    if refute_counts["high"] > 0:
+        idx = max(0, idx - 2)
+    elif refute_counts["medium"] > 0 or refute_counts["low"] > 0:
+        idx = max(0, idx - 1)
+    grade = grade_order[idx]
+
+    parts: list[str] = []
+    if total_support:
+        parts.append(
+            f"supporting evidence – high:{support_counts['high']} medium:{support_counts['medium']} low:{support_counts['low']}"
+        )
+    if total_refute:
+        parts.append(
+            f"refuting evidence – high:{refute_counts['high']} medium:{refute_counts['medium']} low:{refute_counts['low']}"
+        )
+    if not parts:
+        parts.append("no linked evidence")
+
+    rationale = "Auto-graded using evidence counts (" + "; ".join(parts) + ")."
+    if total_refute:
+        rationale += " Conflicting evidence reduced confidence."
+
+    return grade, rationale
+

--- a/tests/test_auto_grade.py
+++ b/tests/test_auto_grade.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from server.core.grading import ClaimEvidence, EvidenceItem, compute_grade
+from worker.auto_grade import AutoGrader
+
+
+@dataclass
+class FakeStore:
+    rows: list[dict]
+
+    def insert(self, claim_id: int, grade: str, rationale: str) -> None:
+        self.rows.append({
+            "claim_id": claim_id,
+            "grade": grade,
+            "rationale": rationale,
+        })
+
+
+def test_compute_grade_strong_support():
+    evidence = [
+        EvidenceItem(stance="supports", type="meta-analysis"),
+        EvidenceItem(stance="supports", type="randomized controlled trial"),
+    ]
+    grade, rationale = compute_grade(evidence)
+    assert grade == "strong"
+    assert "supporting evidence" in rationale
+
+
+def test_auto_grader_handles_multiple_claims():
+    claims = []
+    for idx in range(12):
+        if idx % 3 == 0:
+            ev = [EvidenceItem(stance="supports", type="meta-analysis")]
+        elif idx % 3 == 1:
+            ev = [EvidenceItem(stance="supports", type="observational")]
+        else:
+            ev = [EvidenceItem(stance="refutes", type="systematic review")]
+        claims.append(ClaimEvidence(claim_id=idx + 1, evidence=tuple(ev)))
+
+    store = FakeStore(rows=[])
+    grader = AutoGrader(source=claims, store=store)
+    total = grader.grade_all()
+
+    assert total == len(claims)
+    assert len(store.rows) == len(claims)
+
+
+def test_regrading_creates_new_row():
+    claim = ClaimEvidence(
+        claim_id=42,
+        evidence=(EvidenceItem(stance="supports", type="meta-analysis"),),
+    )
+    store = FakeStore(rows=[])
+    grader = AutoGrader(source=[claim], store=store)
+
+    first_total = grader.grade_all()
+    assert first_total == 1
+    assert len(store.rows) == 1
+    first_snapshot = list(store.rows)
+
+    second_total = grader.grade_all()
+    assert second_total == 1
+    assert len(store.rows) == 2
+    assert store.rows[0] == first_snapshot[0]
+    assert store.rows[1]["claim_id"] == 42
+    assert store.rows[1]["grade"] == store.rows[0]["grade"]

--- a/worker/auto_grade.py
+++ b/worker/auto_grade.py
@@ -1,0 +1,100 @@
+"""Command line entry-point for auto grading claims based on evidence."""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import Iterable, Iterator
+
+try:  # pragma: no cover - optional dependency during tests
+    import psycopg
+except ModuleNotFoundError:  # pragma: no cover - fallback for unit tests without psycopg installed
+    psycopg = None  # type: ignore[assignment]
+
+from server.core.grading import (
+    AUTO_GRADED_BY,
+    RUBRIC_VERSION,
+    ClaimEvidence,
+    EvidenceItem,
+    compute_grade,
+)
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/podcast_plow",
+)
+
+
+class ClaimSource:
+    """Iterable view of claims and their evidence from Postgres."""
+
+    def __init__(self, conn):
+        self.conn = conn
+
+    def __iter__(self) -> Iterator[ClaimEvidence]:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            SELECT c.id, ce.stance, es.type
+            FROM claim c
+            LEFT JOIN claim_evidence ce ON ce.claim_id = c.id
+            LEFT JOIN evidence_source es ON es.id = ce.evidence_id
+            ORDER BY c.id
+            """
+        )
+        by_claim: dict[int, list[EvidenceItem]] = defaultdict(list)
+        claim_order: list[int] = []
+        for claim_id, stance, ev_type in cur.fetchall():
+            if claim_id not in by_claim:
+                claim_order.append(claim_id)
+            by_claim[claim_id].append(EvidenceItem(stance=stance, type=ev_type))
+
+        for claim_id in claim_order:
+            yield ClaimEvidence(claim_id=claim_id, evidence=tuple(by_claim[claim_id]))
+
+
+class GradeStore:
+    """Persists computed grades back into Postgres."""
+
+    def __init__(self, conn):
+        self.conn = conn
+
+    def insert(self, claim_id: int, grade: str, rationale: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO claim_grade (claim_id, grade, rationale, rubric_version, graded_by)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (claim_id, grade, rationale, RUBRIC_VERSION, AUTO_GRADED_BY),
+        )
+
+
+class AutoGrader:
+    """Orchestrates fetching evidence, grading, and persisting results."""
+
+    def __init__(self, source: Iterable[ClaimEvidence], store: GradeStore):
+        self.source = source
+        self.store = store
+
+    def grade_all(self) -> int:
+        graded = 0
+        for claim in self.source:
+            grade, rationale = compute_grade(claim.evidence)
+            self.store.insert(claim.claim_id, grade, rationale)
+            graded += 1
+        return graded
+
+
+def main() -> None:
+    if psycopg is None:  # pragma: no cover - safety guard
+        raise RuntimeError("psycopg is required to run the auto grader")
+    with psycopg.connect(DATABASE_URL, autocommit=True) as conn:
+        grader = AutoGrader(source=ClaimSource(conn), store=GradeStore(conn))
+        total = grader.grade_all()
+        print(f"Auto-graded {total} claims using rubric {RUBRIC_VERSION}.")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add heuristics for classifying evidence strength and generating claim grades
- provide a worker command that persists versioned auto-grades and surface rationales in the topic API
- document the workflow and cover it with unit tests, including re-grading behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15b5540ec832480f04a956da22fee