### PR TITLE
Add job queue worker and summarization pipeline

### DIFF
--- a/server/manage.py
+++ b/server/manage.py
@@ -1,21 +1,75 @@
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 
+from db.utils import db_conn
 from ingest import feeds as feeds_module
 from ingest import summaries as summaries_module
 from ingest import transcripts as transcripts_module
+from services import jobs as jobs_service
+from services import summarize as summarize_service
 
 app = typer.Typer(help="Podcast ingestion and summarisation utilities")
+enqueue_app = typer.Typer(help="Job queue helpers")
+app.add_typer(enqueue_app, name="enqueue")
 
 
 def _configure_logging(verbose: bool) -> None:
     level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(level=level, format="%(levelname)s %(message)s")
+
+
+def _parse_episode_ids(raw: str) -> List[int]:
+    parts = [value.strip() for value in raw.split(",") if value.strip()]
+    if not parts:
+        raise typer.BadParameter("Provide at least one episode id")
+
+    episode_ids: List[int] = []
+    for part in parts:
+        try:
+            episode_ids.append(int(part))
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise typer.BadParameter(f"Invalid episode id '{part}'") from exc
+    return episode_ids
+
+
+def _process_job(conn, job: jobs_service.Job) -> None:
+    if job.job_type == "summarize":
+        episode_id = job.payload.get("episode_id")
+        if episode_id is None:
+            raise ValueError("summarize job missing episode_id in payload")
+        try:
+            episode_int = int(episode_id)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Invalid episode_id value {episode_id!r}") from exc
+        refresh_flag = bool(job.payload.get("refresh", False))
+        summarize_service.summarize_episode(conn, episode_int, refresh=refresh_flag)
+        return
+
+    raise ValueError(f"Unsupported job type: {job.job_type}")
+
+
+@enqueue_app.command("summarize")
+def enqueue_summarize(
+    episode_ids: str = typer.Option(..., "--episode-ids", help="Comma separated list of episode ids"),
+    priority: int = typer.Option(0, "--priority", "-p", help="Higher numbers run before lower priority"),
+    refresh: bool = typer.Option(False, "--refresh", help="Regenerate transcript chunks before summarising"),
+) -> None:
+    ids = _parse_episode_ids(episode_ids)
+    with db_conn() as conn:
+        for episode_id in ids:
+            jobs_service.enqueue_job(
+                conn,
+                job_type="summarize",
+                payload={"episode_id": episode_id, "refresh": refresh},
+                priority=priority,
+            )
+    typer.echo(f"Enqueued {len(ids)} summarisation job(s).")
 
 
 @app.callback()
@@ -31,6 +85,47 @@ def discover(
 
     inserted = feeds_module.discover_from_file(feeds)
     typer.echo(f"Inserted {inserted} new episodes from feeds in {feeds}.")
+
+
+@app.command()
+def work(
+    once: bool = typer.Option(False, "--once", help="Process at most one job and then exit"),
+    loop: bool = typer.Option(False, "--loop", help="Continuously poll for new jobs"),
+    poll_interval: float = typer.Option(5.0, "--poll-interval", help="Seconds to wait between polls when idle"),
+) -> None:
+    if once and loop:
+        raise typer.BadParameter("Choose either --once or --loop, not both")
+
+    should_loop = loop or not once
+    poll_interval = max(poll_interval, 0.1)
+
+    while True:
+        job: jobs_service.Job | None = None
+        with db_conn() as conn:
+            job = jobs_service.dequeue_job(conn)
+            if job is None:
+                # Close connection before potentially sleeping
+                pass
+            else:
+                logger.info("Processing job %s (%s)", job.id, job.job_type)
+                try:
+                    _process_job(conn, job)
+                except Exception as exc:
+                    logger.exception("Job %s failed", job.id)
+                    jobs_service.mark_job_failed(conn, job, str(exc))
+                else:
+                    jobs_service.mark_job_done(conn, job.id)
+
+        if job is None:
+            if should_loop:
+                logger.debug("No queued jobs; sleeping for %s seconds", poll_interval)
+                time.sleep(poll_interval)
+                continue
+            typer.echo("No queued jobs available.")
+            break
+
+        if not should_loop:
+            break
 
 
 @app.command("fetch-transcripts")
@@ -52,6 +147,22 @@ def summarize(
 
     updated = summaries_module.summarize(limit, refresh=refresh)
     typer.echo(f"Generated summaries for {updated} episodes.")
+
+
+@app.command("summarize-episode")
+def summarize_episode(
+    episode_id: int = typer.Option(..., "--episode-id", "-e", help="Episode id to summarise"),
+    refresh: bool = typer.Option(False, "--refresh", help="Regenerate transcript chunks before summarising"),
+) -> None:
+    try:
+        with db_conn() as conn:
+            result = summarize_service.summarize_episode(conn, episode_id, refresh=refresh)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1)
+    typer.echo(
+        f"Generated summary for episode {episode_id} ({len(result.key_points)} bullet points)."
+    )
 
 
 if __name__ == "__main__":

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,3 +8,4 @@ feedparser>=6.0,<7.0
 requests>=2.32,<3.0
 beautifulsoup4>=4.12,<4.13
 lxml>=5.3,<5.4
+sumy>=0.11,<0.12

--- a/server/services/chunker.py
+++ b/server/services/chunker.py
@@ -1,0 +1,254 @@
+"""Utilities to break transcripts into manageable chunks."""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_TOKENS = 1800
+DEFAULT_OVERLAP_RATIO = 0.1
+
+
+@dataclass
+class TranscriptRecord:
+    """Representation of a transcript row."""
+
+    id: int
+    episode_id: int
+    text: str
+    word_count: int | None = None
+
+
+@dataclass
+class ChunkData:
+    """Metadata about a chunk ready to be persisted."""
+
+    chunk_index: int
+    token_start: int
+    token_end: int
+    token_count: int
+    text: str
+
+
+@dataclass
+class ChunkRecord(ChunkData):
+    """Chunk information loaded from the database."""
+
+    id: int
+    transcript_id: int
+    key_points: str | None = None
+
+
+@dataclass
+class ChunkingResult:
+    """Return value from :func:`ensure_chunks_for_episode`."""
+
+    transcript: TranscriptRecord
+    chunks: List[ChunkRecord]
+
+
+_token_pattern = re.compile(r"\S+")
+
+
+def _tokenize(text: str) -> List[str]:
+    return _token_pattern.findall(text)
+
+
+def _tokens_to_text(tokens: Sequence[str]) -> str:
+    return " ".join(tokens).strip()
+
+
+def _build_chunks(tokens: Sequence[str], *, max_tokens: int, overlap_ratio: float) -> List[ChunkData]:
+    if not tokens:
+        return []
+
+    chunk_size = max(max_tokens, 1)
+    overlap = int(math.floor(chunk_size * overlap_ratio))
+    if overlap >= chunk_size:
+        overlap = max(chunk_size - 1, 0)
+
+    chunks: List[ChunkData] = []
+    start = 0
+    index = 0
+
+    while start < len(tokens):
+        end = min(len(tokens), start + chunk_size)
+        chunk_tokens = tokens[start:end]
+        if not chunk_tokens:
+            break
+        text = _tokens_to_text(chunk_tokens)
+        chunks.append(
+            ChunkData(
+                chunk_index=index,
+                token_start=start,
+                token_end=end,
+                token_count=len(chunk_tokens),
+                text=text,
+            )
+        )
+        if end >= len(tokens):
+            break
+        start = max(0, end - overlap)
+        if start == end:
+            start += 1
+        index += 1
+
+    return chunks
+
+
+def _fetch_transcript(conn, episode_id: int) -> TranscriptRecord | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, episode_id, text, word_count
+            FROM transcript
+            WHERE episode_id = %s AND text IS NOT NULL AND text <> ''
+            ORDER BY word_count DESC NULLS LAST, id DESC
+            LIMIT 1
+            """,
+            (episode_id,),
+        )
+        row = cur.fetchone()
+
+    if not row:
+        logger.debug("No transcript found for episode %s", episode_id)
+        return None
+
+    transcript = TranscriptRecord(id=row[0], episode_id=row[1], text=row[2], word_count=row[3])
+    return transcript
+
+
+def _count_existing_chunks(conn, transcript_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM transcript_chunk WHERE transcript_id = %s",
+            (transcript_id,),
+        )
+        row = cur.fetchone()
+    return int(row[0] if row else 0)
+
+
+def _persist_chunks(
+    conn,
+    transcript_id: int,
+    text: str,
+    *,
+    max_tokens: int,
+    overlap_ratio: float,
+) -> List[ChunkData]:
+    tokens = _tokenize(text)
+    chunk_data = _build_chunks(tokens, max_tokens=max_tokens, overlap_ratio=overlap_ratio)
+
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM transcript_chunk WHERE transcript_id = %s", (transcript_id,))
+        for chunk in chunk_data:
+            cur.execute(
+                """
+                INSERT INTO transcript_chunk (
+                    transcript_id, chunk_index, token_start, token_end, token_count, text
+                )
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    transcript_id,
+                    chunk.chunk_index,
+                    chunk.token_start,
+                    chunk.token_end,
+                    chunk.token_count,
+                    chunk.text,
+                ),
+            )
+
+    logger.info("Created %d transcript chunks for transcript %s", len(chunk_data), transcript_id)
+    return chunk_data
+
+
+def fetch_chunks(conn, transcript_id: int) -> List[ChunkRecord]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, transcript_id, chunk_index, token_start, token_end, token_count, text, key_points
+            FROM transcript_chunk
+            WHERE transcript_id = %s
+            ORDER BY chunk_index
+            """,
+            (transcript_id,),
+        )
+        rows = cur.fetchall()
+
+    chunks: List[ChunkRecord] = []
+    for row in rows:
+        chunks.append(
+            ChunkRecord(
+                id=row[0],
+                transcript_id=row[1],
+                chunk_index=row[2],
+                token_start=row[3],
+                token_end=row[4],
+                token_count=row[5],
+                text=row[6],
+                key_points=row[7],
+            )
+        )
+    return chunks
+
+
+def ensure_chunks_for_episode(
+    conn,
+    episode_id: int,
+    *,
+    refresh: bool = False,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    overlap_ratio: float = DEFAULT_OVERLAP_RATIO,
+) -> ChunkingResult | None:
+    transcript = _fetch_transcript(conn, episode_id)
+    if transcript is None:
+        return None
+
+    needs_refresh = refresh or _count_existing_chunks(conn, transcript.id) == 0
+    if needs_refresh:
+        _persist_chunks(
+            conn,
+            transcript.id,
+            transcript.text,
+            max_tokens=max_tokens,
+            overlap_ratio=overlap_ratio,
+        )
+
+    chunks = fetch_chunks(conn, transcript.id)
+    if not chunks:
+        logger.warning("Transcript %s has no chunks after processing", transcript.id)
+        return None
+    return ChunkingResult(transcript=transcript, chunks=chunks)
+
+
+def serialize_key_points(points: Iterable[str]) -> str | None:
+    cleaned = [point.strip() for point in points if point and point.strip()]
+    if not cleaned:
+        return None
+    return "\n".join(f"- {point}" for point in cleaned)
+
+
+def update_chunk_key_points(conn, chunk_id: int, points: Iterable[str]) -> None:
+    serialized = serialize_key_points(points)
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE transcript_chunk SET key_points = %s WHERE id = %s",
+            (serialized, chunk_id),
+        )
+    logger.debug("Stored key points for chunk %s", chunk_id)
+
+
+__all__ = [
+    "ChunkingResult",
+    "ChunkRecord",
+    "ensure_chunks_for_episode",
+    "fetch_chunks",
+    "serialize_key_points",
+    "update_chunk_key_points",
+]

--- a/server/services/jobs.py
+++ b/server/services/jobs.py
@@ -1,0 +1,211 @@
+"""Simple database-backed job queue helpers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+UTC = dt.timezone.utc
+
+
+@dataclass
+class Job:
+    """Representation of a job queued in the database."""
+
+    id: int
+    job_type: str
+    payload: Dict[str, Any]
+    status: str
+    priority: int
+    run_at: dt.datetime
+    attempts: int
+    max_attempts: int
+    last_error: Optional[str] = None
+
+
+def _ensure_datetime(value: Any) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    if isinstance(value, (int, float)):
+        return dt.datetime.fromtimestamp(value, tz=UTC)
+    return dt.datetime.now(tz=UTC)
+
+
+def _parse_payload(value: Any) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            logger.debug("Unable to decode payload JSON; falling back to empty dict")
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _row_to_job(row: Any) -> Job:
+    job_id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error = row
+    return Job(
+        id=int(job_id),
+        job_type=str(job_type),
+        payload=_parse_payload(payload),
+        status=str(status),
+        priority=int(priority),
+        run_at=_ensure_datetime(run_at),
+        attempts=int(attempts),
+        max_attempts=int(max_attempts),
+        last_error=last_error,
+    )
+
+
+def enqueue_job(
+    conn,
+    job_type: str,
+    payload: Dict[str, Any] | None = None,
+    *,
+    priority: int = 0,
+    run_at: dt.datetime | None = None,
+    max_attempts: int = 3,
+) -> Job:
+    payload = payload or {}
+    run_at = run_at or dt.datetime.now(tz=UTC)
+    serialized_payload = json.dumps(payload)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO job_queue (job_type, payload, priority, run_at, max_attempts)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error
+            """,
+            (job_type, serialized_payload, priority, run_at, max_attempts),
+        )
+        row = cur.fetchone()
+    job = _row_to_job(row)
+    logger.info("Enqueued job %s (type=%s) with priority %s", job.id, job.job_type, job.priority)
+    return job
+
+
+def dequeue_job(conn) -> Job | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error
+            FROM job_queue
+            WHERE status = %s AND run_at <= now()
+            ORDER BY priority DESC, run_at, id
+            LIMIT 1
+            """,
+            ("queued",),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+
+    job = _row_to_job(row)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE job_queue
+            SET status = %s,
+                attempts = attempts + 1,
+                started_at = now(),
+                updated_at = now()
+            WHERE id = %s
+            """,
+            ("running", job.id),
+        )
+    job.status = "running"
+    job.attempts += 1
+    return job
+
+
+def mark_job_done(conn, job_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE job_queue
+            SET status = %s,
+                finished_at = now(),
+                last_error = NULL,
+                updated_at = now()
+            WHERE id = %s
+            """,
+            ("done", job_id),
+        )
+    logger.info("Job %s completed", job_id)
+
+
+def mark_job_failed(
+    conn,
+    job: Job,
+    error: str,
+    *,
+    backoff_seconds: int | None = None,
+) -> None:
+    message = (error or "").strip()
+    if len(message) > 2000:
+        message = message[:2000]
+
+    if job.attempts >= job.max_attempts:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE job_queue
+                SET status = %s,
+                    finished_at = now(),
+                    last_error = %s,
+                    updated_at = now()
+                WHERE id = %s
+                """,
+                ("failed", message or None, job.id),
+            )
+        logger.warning("Job %s permanently failed after %s attempts", job.id, job.attempts)
+        return
+
+    if backoff_seconds is None:
+        backoff_seconds = min(3600, max(30, job.attempts * 60))
+    next_run = dt.datetime.now(tz=UTC) + dt.timedelta(seconds=backoff_seconds)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE job_queue
+            SET status = %s,
+                run_at = %s,
+                last_error = %s,
+                started_at = NULL,
+                finished_at = NULL,
+                updated_at = now()
+            WHERE id = %s
+            """,
+            ("queued", next_run, message or None, job.id),
+        )
+    job.status = "queued"
+    job.run_at = next_run
+    logger.info(
+        "Job %s requeued after failure (attempt %s/%s)",
+        job.id,
+        job.attempts,
+        job.max_attempts,
+    )
+
+
+__all__ = [
+    "Job",
+    "enqueue_job",
+    "dequeue_job",
+    "mark_job_done",
+    "mark_job_failed",
+]

--- a/server/services/summarize.py
+++ b/server/services/summarize.py
@@ -1,0 +1,172 @@
+"""Map/reduce style summarisation helpers."""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from sumy.nlp.tokenizers import Tokenizer
+from sumy.parsers.plaintext import PlaintextParser
+from sumy.summarizers.luhn import LuhnSummarizer
+
+from . import chunker
+
+logger = logging.getLogger(__name__)
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+@dataclass
+class SummaryResult:
+    """Summary data returned by :func:`summarize_episode`."""
+
+    tl_dr: str
+    narrative: str
+    key_points: List[str]
+
+
+def _fallback_sentences(text: str, limit: int) -> List[str]:
+    pieces = _SENTENCE_SPLIT.split(text)
+    results: List[str] = []
+    for piece in pieces:
+        cleaned = re.sub(r"\s+", " ", piece).strip()
+        if not cleaned:
+            continue
+        results.append(cleaned)
+        if len(results) >= limit:
+            break
+    return results
+
+
+def _summarize_chunk_text(text: str, desired_points: int) -> List[str]:
+    if not text.strip():
+        return []
+
+    parser = PlaintextParser.from_string(text, Tokenizer("english"))
+    summarizer = LuhnSummarizer()
+    try:
+        sentences = summarizer(parser.document, desired_points)
+    except ValueError:
+        sentences = []
+
+    points: List[str] = []
+    for sentence in sentences:
+        cleaned = re.sub(r"\s+", " ", str(sentence)).strip()
+        if cleaned:
+            points.append(cleaned)
+
+    if not points:
+        points = _fallback_sentences(text, desired_points)
+
+    return points
+
+
+def _dedupe_points(points: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    cleaned: List[str] = []
+    for point in points:
+        normalized = re.sub(r"\s+", " ", point).strip()
+        if not normalized:
+            continue
+        key = normalized.rstrip(".").lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(normalized.rstrip("."))
+    return cleaned
+
+
+def _select_points(points: Sequence[str], *, minimum: int = 5, maximum: int = 8) -> List[str]:
+    if not points:
+        return []
+    trimmed = list(points[:maximum])
+    if len(trimmed) < minimum and len(points) >= minimum:
+        trimmed = list(points[:minimum])
+    return trimmed
+
+
+def _format_tldr(points: Sequence[str]) -> str:
+    if not points:
+        return ""
+    return "\n".join(f"- {point}" for point in points)
+
+
+def _ensure_sentence(text: str) -> str:
+    cleaned = text.strip()
+    if not cleaned.endswith(('.', '!', '?')):
+        cleaned = f"{cleaned}."
+    return cleaned
+
+
+def _build_narrative(points: Sequence[str]) -> str:
+    if not points:
+        return ""
+    sentences = [_ensure_sentence(point) for point in points]
+    if len(sentences) <= 4:
+        return " ".join(sentences)
+    midpoint = math.ceil(len(sentences) / 2)
+    first = " ".join(sentences[:midpoint]).strip()
+    second = " ".join(sentences[midpoint:]).strip()
+    if second:
+        return f"{first}\n\n{second}"
+    return first
+
+
+def _store_summary(
+    conn,
+    episode_id: int,
+    *,
+    tl_dr: str,
+    narrative: str,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM episode_summary WHERE episode_id = %s AND created_by IN (%s, %s)",
+            (episode_id, "worker", "pipeline"),
+        )
+        cur.execute(
+            """
+            INSERT INTO episode_summary (episode_id, tl_dr, narrative, created_by)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (episode_id, tl_dr, narrative, "worker"),
+        )
+
+
+def summarize_episode(
+    conn,
+    episode_id: int,
+    *,
+    refresh: bool = False,
+) -> SummaryResult:
+    chunk_data = chunker.ensure_chunks_for_episode(conn, episode_id, refresh=refresh)
+    if chunk_data is None:
+        raise ValueError(f"No transcript available for episode {episode_id}")
+
+    all_points: List[str] = []
+    for chunk in chunk_data.chunks:
+        desired = max(3, min(7, math.ceil(chunk.token_count / 400)))
+        points = _summarize_chunk_text(chunk.text, desired)
+        if points:
+            chunker.update_chunk_key_points(conn, chunk.id, points)
+            all_points.extend(points)
+        else:
+            chunker.update_chunk_key_points(conn, chunk.id, [])
+
+    deduped = _dedupe_points(all_points)
+    if not deduped:
+        deduped = _dedupe_points(_fallback_sentences(chunk_data.transcript.text, 8))
+
+    selected = _select_points(deduped)
+    tl_dr = _format_tldr(selected)
+    narrative = _build_narrative(selected)
+
+    _store_summary(conn, episode_id, tl_dr=tl_dr, narrative=narrative)
+    logger.info("Generated summary for episode %s (%d bullet points)", episode_id, len(selected))
+    return SummaryResult(tl_dr=tl_dr, narrative=narrative, key_points=selected)
+
+
+__all__ = ["SummaryResult", "summarize_episode"]


### PR DESCRIPTION
## Summary
- introduce transcript chunking, map/reduce summarisation services, and a persistent job queue
- extend the management CLI with enqueue, worker, and direct summarisation commands driven by the new services
- update database schema, requirements, and test fakes to support transcript chunks, job queue operations, and the sumy summariser

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2b689d80083249fee312f1b29fe2e