### PR TITLE
Fix FastAPI server startup and test utilities

### DIFF
--- a/server/services/grader.py
+++ b/server/services/grader.py
@@ -183,13 +183,16 @@ def compute_grade(evidence_items: Iterable[EvidenceItem]) -> tuple[str, str]:
         grade = "unsupported"
 
     summary = _format_summary(meta, rct, observational, weak)
-    rationale = f"Auto-graded as {grade} based on {summary}."
+    rationale_parts = [
+        f"Auto-graded as {grade} because supporting evidence includes {summary}."
+    ]
     if total_refute:
+        rationale_parts.append("Conflicting evidence reduced confidence.")
         ref_summary = _format_summary(
             refute["meta"], refute["rct"], refute["observational"], refute["weak"]
         )
-        rationale += f" Refuting evidence noted ({ref_summary})."
-    return grade, rationale
+        rationale_parts.append(f"Refuting evidence noted ({ref_summary}).")
+    return grade, " ".join(part.strip() for part in rationale_parts if part)
 
 
 class AutoGradeService:


### PR DESCRIPTION
## Summary
- update the auto-grader rationale so the API responses include the expected phrasing
- expand the fake database shim to cover job queue, transcript chunking, and claim update queries used by the API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2d907a01883248ae6f901354f5baf