### PR TITLE
Fix server module imports for container

### DIFF
--- a/server/api/jobs.py
+++ b/server/api/jobs.py
@@ -1,5 +1,4 @@
 """Administrative endpoints for managing background jobs."""
-
 from __future__ import annotations
 
 from copy import deepcopy
@@ -9,7 +8,12 @@ from typing import Any, Iterable, Sequence
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 
-from server.db.utils import db_conn
+try:  # pragma: no cover - executed in Docker container
+    from server.db.utils import db_conn
+except ModuleNotFoundError as exc:  # pragma: no cover - executed locally
+    if exc.name not in {"server", "server.db", "server.db.utils"}:
+        raise
+    from db.utils import db_conn
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
 

--- a/server/app.py
+++ b/server/app.py
@@ -2,11 +2,14 @@ from fastapi import FastAPI, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from core.db import db_connection  # IMPORTANT: import from /app root
 
-from server.db.utils import db_conn
-from server.api.jobs import router as jobs_router
-
-from core.db import db_connection   # IMPORTANT: import from /app root
+try:  # pragma: no cover - exercised in Docker container
+    from server.api.jobs import router as jobs_router
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised locally
+    if exc.name not in {"server", "server.api", "server.api.jobs"}:
+        raise
+    from api.jobs import router as jobs_router
 
 
 


### PR DESCRIPTION
## Summary
- allow the FastAPI application to import the jobs router when the `server` package name is not available inside the Docker volume
- add a guarded fallback import for the jobs API so it can still locate the database helpers when mounted at `/app`

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'tests.fake_db' due to third-party `tests` package on sys.path)*
- PYTHONPATH=. pytest tests/test_health.py


------
https://chatgpt.com/codex/tasks/task_e_68d3adcba5888324b223a2f3d2b22f2a