### PR TITLE
Add tests package init

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker to allow relative imports in pytest."""


### PR DESCRIPTION
## Summary
- add a package marker in the tests directory so pytest can import helper modules via package notation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b2fa3e8c83248bee1b53c4f45339