### PR TITLE
Unify jobs API with job_queue

### DIFF
--- a/infra/initdb/002_jobs_and_chunks.sql
+++ b/infra/initdb/002_jobs_and_chunks.sql
@@ -3,19 +3,23 @@
 -- Job queue for background work
 CREATE TABLE IF NOT EXISTS job_queue (
   id SERIAL PRIMARY KEY,
-  job_type TEXT,
-  payload_json JSONB,
-  status TEXT,
-  priority INT DEFAULT 5,
-  attempts INT DEFAULT 0,
-  error TEXT,
-  created_at TIMESTAMPTZ DEFAULT now(),
+  job_type TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status TEXT NOT NULL DEFAULT 'queued',
+  priority INT NOT NULL DEFAULT 0,
+  run_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  attempts INT NOT NULL DEFAULT 0,
+  max_attempts INT NOT NULL DEFAULT 3,
+  last_error TEXT,
+  result JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   started_at TIMESTAMPTZ,
-  finished_at TIMESTAMPTZ
+  finished_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_job_queue_status_priority_created_at
-  ON job_queue (status, priority, created_at);
+CREATE INDEX IF NOT EXISTS idx_job_queue_status_priority_run_at
+  ON job_queue (status, priority, run_at);
 
 -- Transcript chunks allow storing smaller units with embeddings
 CREATE TABLE IF NOT EXISTS transcript_chunk (

--- a/infra/initdb/003_unify_jobs.sql
+++ b/infra/initdb/003_unify_jobs.sql
@@ -1,0 +1,92 @@
+-- Migrate legacy job table entries into the unified job_queue table.
+
+-- Rename old columns if present from earlier schema versions.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'job_queue' AND column_name = 'payload_json'
+    ) THEN
+        EXECUTE 'ALTER TABLE job_queue RENAME COLUMN payload_json TO payload';
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'job_queue' AND column_name = 'error'
+    ) THEN
+        EXECUTE 'ALTER TABLE job_queue RENAME COLUMN error TO last_error';
+    END IF;
+END
+$$;
+
+-- Ensure required columns exist with appropriate defaults.
+ALTER TABLE job_queue
+    ADD COLUMN IF NOT EXISTS payload JSONB DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS run_at TIMESTAMPTZ DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS max_attempts INT NOT NULL DEFAULT 3,
+    ADD COLUMN IF NOT EXISTS result JSONB,
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS finished_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_error TEXT;
+
+ALTER TABLE job_queue
+    ALTER COLUMN job_type SET NOT NULL,
+    ALTER COLUMN status SET NOT NULL,
+    ALTER COLUMN status SET DEFAULT 'queued',
+    ALTER COLUMN priority SET NOT NULL,
+    ALTER COLUMN priority SET DEFAULT 0,
+    ALTER COLUMN attempts SET NOT NULL,
+    ALTER COLUMN attempts SET DEFAULT 0,
+    ALTER COLUMN payload SET DEFAULT '{}'::jsonb,
+    ALTER COLUMN payload SET NOT NULL,
+    ALTER COLUMN run_at SET DEFAULT now(),
+    ALTER COLUMN run_at SET NOT NULL,
+    ALTER COLUMN created_at SET DEFAULT now(),
+    ALTER COLUMN created_at SET NOT NULL,
+    ALTER COLUMN updated_at SET DEFAULT now(),
+    ALTER COLUMN updated_at SET NOT NULL;
+
+-- Backfill missing values for existing rows.
+UPDATE job_queue
+SET
+    payload = COALESCE(payload, '{}'::jsonb),
+    priority = COALESCE(priority, 0),
+    attempts = COALESCE(attempts, 0),
+    max_attempts = COALESCE(max_attempts, 3),
+    status = COALESCE(status, 'queued'),
+    run_at = COALESCE(run_at, created_at, now()),
+    created_at = COALESCE(created_at, now()),
+    updated_at = COALESCE(updated_at, created_at, now());
+
+-- Copy data from the legacy job table if it exists.
+INSERT INTO job_queue (id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error, result, created_at, started_at, finished_at, updated_at)
+SELECT
+    id,
+    job_type,
+    payload,
+    status,
+    COALESCE(priority, 0),
+    COALESCE(updated_at, created_at, now()),
+    0,
+    3,
+    error,
+    result,
+    created_at,
+    NULL,
+    NULL,
+    COALESCE(updated_at, created_at, now())
+FROM job
+ON CONFLICT (id) DO NOTHING;
+
+-- Align the sequence with the highest identifier in the queue.
+SELECT setval('job_queue_id_seq', GREATEST((SELECT COALESCE(MAX(id), 0) FROM job_queue), 1));
+
+-- Drop the legacy job table now that data has been migrated.
+DROP TABLE IF EXISTS job;

--- a/server/api/jobs.py
+++ b/server/api/jobs.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
+
+from server.services import jobs as jobs_service
 
 try:  # pragma: no cover - executed in Docker container
     from server.db.utils import db_conn
@@ -16,10 +18,6 @@ except ModuleNotFoundError as exc:  # pragma: no cover - executed locally
     from db.utils import db_conn
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
-
-JOB_RETURNING_COLUMNS = (
-    "id, job_type, status, payload, result, error, created_at, updated_at, priority"
-)
 ALLOWED_STATUSES = {"queued", "running", "failed", "done"}
 ACTIVE_STATUSES = {"queued", "running"}
 
@@ -151,34 +149,17 @@ class JobCreateRequest(BaseModel):
             yield deepcopy(payload)
 
 
-def _row_to_job(row: Sequence[Any] | None) -> JobResponse:
-    if row is None:
-        raise ValueError("Expected database row but received None")
-    if isinstance(row, dict):
-        data = row
-    else:
-        keys = (
-            "id",
-            "job_type",
-            "status",
-            "payload",
-            "result",
-            "error",
-            "created_at",
-            "updated_at",
-            "priority",
-        )
-        data = dict(zip(keys, row, strict=False))
+def _job_to_response(job: jobs_service.Job) -> JobResponse:
     return JobResponse(
-        id=data.get("id"),
-        job_type=data.get("job_type"),
-        status=data.get("status"),
-        payload=data.get("payload"),
-        result=data.get("result"),
-        error=data.get("error"),
-        created_at=_normalize_timestamp(data.get("created_at")),
-        updated_at=_normalize_timestamp(data.get("updated_at")),
-        priority=int(data.get("priority") or 0),
+        id=job.id,
+        job_type=job.job_type,
+        status=job.status,
+        payload=job.payload,
+        result=job.result,
+        error=job.last_error,
+        created_at=_normalize_timestamp(job.created_at),
+        updated_at=_normalize_timestamp(job.updated_at),
+        priority=int(job.priority or 0),
     )
 
 
@@ -191,40 +172,27 @@ def enqueue_jobs(request: JobCreateRequest) -> JobListResponse:
     seen_job_ids: set[int] = set()
     dedupe_enabled = bool(request.dedupe)
     with db_conn() as conn:
-        with conn.cursor() as cur:
-            for payload in payloads:
-                if dedupe_enabled:
-                    cur.execute(
-                        f"""
-                        SELECT {JOB_RETURNING_COLUMNS}
-                        FROM job
-                        WHERE job_type = %s AND payload = %s
-                        ORDER BY id DESC
-                        LIMIT 1
-                        """,
-                        (request.job_type, payload),
-                    )
-                    existing = cur.fetchone()
-                    if existing:
-                        job = _row_to_job(existing)
-                        if job.status in ACTIVE_STATUSES:
-                            if job.id not in seen_job_ids:
-                                jobs.append(job)
-                                seen_job_ids.add(job.id)
-                            continue
-                cur.execute(
-                    f"""
-                    INSERT INTO job (job_type, status, payload, priority)
-                    VALUES (%s, %s, %s, %s)
-                    RETURNING {JOB_RETURNING_COLUMNS}
-                    """,
-                    (request.job_type, "queued", payload, request.priority),
+        for payload in payloads:
+            if dedupe_enabled:
+                existing = jobs_service.find_job_by_payload(
+                    conn,
+                    job_type=request.job_type,
+                    payload=payload,
                 )
-                row = cur.fetchone()
-                job = _row_to_job(row)
-                if job.id not in seen_job_ids:
-                    jobs.append(job)
-                    seen_job_ids.add(job.id)
+                if existing and existing.status in ACTIVE_STATUSES:
+                    if existing.id not in seen_job_ids:
+                        jobs.append(_job_to_response(existing))
+                        seen_job_ids.add(existing.id)
+                    continue
+            job = jobs_service.enqueue_job(
+                conn,
+                job_type=request.job_type,
+                payload=payload,
+                priority=request.priority,
+            )
+            if job.id not in seen_job_ids:
+                jobs.append(_job_to_response(job))
+                seen_job_ids.add(job.id)
     return JobListResponse(jobs=jobs, count=len(jobs))
 
 
@@ -253,40 +221,28 @@ def list_jobs(
 ) -> JobListResponse:
     """Return jobs ordered from newest to oldest with optional filtering."""
 
-    params: list[Any] = []
-    filters: list[str] = []
+    normalized_status: str | None = None
     if status is not None:
         normalized_status = status.strip().lower()
         if normalized_status not in ALLOWED_STATUSES:
             raise HTTPException(status_code=400, detail="invalid status filter")
-        filters.append("status = %s")
-        params.append(normalized_status)
 
+    normalized_type: str | None = None
     if job_type is not None:
         normalized_type = job_type.strip()
         if not normalized_type:
             raise HTTPException(status_code=400, detail="invalid type filter")
-        filters.append("job_type = %s")
-        params.append(normalized_type)
-
-    sql = f"SELECT {JOB_RETURNING_COLUMNS} FROM job"
-    if filters:
-        sql += " WHERE " + " AND ".join(filters)
-    sql += " ORDER BY priority DESC, id DESC"
-    if limit is not None:
-        sql += " LIMIT %s"
-        params.append(limit)
-    if offset:
-        sql += " OFFSET %s"
-        params.append(offset)
-
     with db_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(sql, params)
-            rows = cur.fetchall()
+        jobs = jobs_service.list_jobs_admin(
+            conn,
+            status=normalized_status,
+            job_type=normalized_type,
+            limit=limit,
+            offset=offset,
+        )
 
-    jobs = [_row_to_job(row) for row in rows]
-    return JobListResponse(jobs=jobs, count=len(jobs))
+    responses = [_job_to_response(job) for job in jobs]
+    return JobListResponse(jobs=responses, count=len(responses))
 
 
 @router.get("/{job_id}", response_model=JobResponse)
@@ -294,17 +250,12 @@ def get_job(job_id: int) -> JobResponse:
     """Return a single job by identifier."""
 
     with db_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT {JOB_RETURNING_COLUMNS} FROM job WHERE id = %s",
-                (job_id,),
-            )
-            row = cur.fetchone()
+        job = jobs_service.get_job(conn, job_id)
 
-    if not row:
+    if job is None:
         raise HTTPException(status_code=404, detail="job not found")
 
-    return _row_to_job(row)
+    return _job_to_response(job)
 
 
 __all__ = [

--- a/server/services/jobs.py
+++ b/server/services/jobs.py
@@ -12,6 +12,25 @@ logger = logging.getLogger(__name__)
 
 UTC = dt.timezone.utc
 
+_JOB_COLUMNS = (
+    "id",
+    "job_type",
+    "payload",
+    "status",
+    "priority",
+    "run_at",
+    "attempts",
+    "max_attempts",
+    "last_error",
+    "result",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "finished_at",
+)
+
+_JOB_SELECT = ", ".join(_JOB_COLUMNS)
+
 
 @dataclass
 class Job:
@@ -26,16 +45,29 @@ class Job:
     attempts: int
     max_attempts: int
     last_error: Optional[str] = None
+    result: Any = None
+    created_at: dt.datetime | None = None
+    updated_at: dt.datetime | None = None
+    started_at: dt.datetime | None = None
+    finished_at: dt.datetime | None = None
 
 
-def _ensure_datetime(value: Any) -> dt.datetime:
+def _ensure_datetime(value: Any, *, default: dt.datetime | None = None) -> dt.datetime:
     if isinstance(value, dt.datetime):
         if value.tzinfo is None:
             return value.replace(tzinfo=UTC)
         return value.astimezone(UTC)
     if isinstance(value, (int, float)):
         return dt.datetime.fromtimestamp(value, tz=UTC)
+    if default is not None:
+        return default
     return dt.datetime.now(tz=UTC)
+
+
+def _ensure_optional_datetime(value: Any) -> dt.datetime | None:
+    if value is None:
+        return None
+    return _ensure_datetime(value)
 
 
 def _parse_payload(value: Any) -> Dict[str, Any]:
@@ -56,18 +88,54 @@ def _parse_payload(value: Any) -> Dict[str, Any]:
     return {}
 
 
+def _parse_result(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            logger.debug("Unable to decode result JSON; returning raw value")
+    return value
+
+
+def _serialize_payload(payload: Dict[str, Any]) -> str:
+    try:
+        return json.dumps(payload, sort_keys=True)
+    except TypeError:
+        logger.debug("Payload not JSON serializable; storing empty object")
+        return json.dumps({}, sort_keys=True)
+
+
 def _row_to_job(row: Any) -> Job:
-    job_id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error = row
+    if isinstance(row, dict):
+        data = row
+    else:
+        data = dict(zip(_JOB_COLUMNS, row, strict=False))
+
+    created_at = _ensure_optional_datetime(data.get("created_at"))
+    updated_at = _ensure_optional_datetime(data.get("updated_at"))
+    run_at = _ensure_datetime(data.get("run_at"), default=created_at)
+
     return Job(
-        id=int(job_id),
-        job_type=str(job_type),
-        payload=_parse_payload(payload),
-        status=str(status),
-        priority=int(priority),
-        run_at=_ensure_datetime(run_at),
-        attempts=int(attempts),
-        max_attempts=int(max_attempts),
-        last_error=last_error,
+        id=int(data.get("id")),
+        job_type=str(data.get("job_type")),
+        payload=_parse_payload(data.get("payload")),
+        status=str(data.get("status")),
+        priority=int(data.get("priority") or 0),
+        run_at=run_at,
+        attempts=int(data.get("attempts") or 0),
+        max_attempts=int(data.get("max_attempts") or 0),
+        last_error=data.get("last_error"),
+        result=_parse_result(data.get("result")),
+        created_at=created_at,
+        updated_at=updated_at,
+        started_at=_ensure_optional_datetime(data.get("started_at")),
+        finished_at=_ensure_optional_datetime(data.get("finished_at")),
     )
 
 
@@ -81,14 +149,28 @@ def enqueue_job(
     max_attempts: int = 3,
 ) -> Job:
     payload = payload or {}
-    run_at = run_at or dt.datetime.now(tz=UTC)
-    serialized_payload = json.dumps(payload)
+    run_at = _ensure_datetime(run_at, default=dt.datetime.now(tz=UTC))
+    serialized_payload = _serialize_payload(payload)
     with conn.cursor() as cur:
         cur.execute(
             """
             INSERT INTO job_queue (job_type, payload, priority, run_at, max_attempts)
             VALUES (%s, %s, %s, %s, %s)
-            RETURNING id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error
+            RETURNING
+                id,
+                job_type,
+                payload,
+                status,
+                priority,
+                run_at,
+                attempts,
+                max_attempts,
+                last_error,
+                result,
+                created_at,
+                updated_at,
+                started_at,
+                finished_at
             """,
             (job_type, serialized_payload, priority, run_at, max_attempts),
         )
@@ -116,8 +198,8 @@ def dequeue_job(conn, job_types: Sequence[str] | None = None) -> Job | None:
         filters.append(f"job_type IN ({placeholders})")
         params.extend(normalized_types)
 
-    sql = """
-        SELECT id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error
+    sql = f"""
+        SELECT {_JOB_SELECT}
         FROM job_queue
     """
     if filters:
@@ -222,12 +304,7 @@ def list_jobs(conn, *, status: str | None = None, limit: int | None = None) -> l
     """Return queued jobs ordered by priority and run time."""
 
     params: list[Any] = []
-    sql = (
-        """
-        SELECT id, job_type, payload, status, priority, run_at, attempts, max_attempts, last_error
-        FROM job_queue
-        """
-    )
+    sql = f"SELECT {_JOB_SELECT} FROM job_queue"
     if status is not None:
         sql += " WHERE status = %s"
         params.append(status)
@@ -245,6 +322,83 @@ def list_jobs(conn, *, status: str | None = None, limit: int | None = None) -> l
     return [_row_to_job(row) for row in rows]
 
 
+def get_job(conn, job_id: int) -> Job | None:
+    """Return a single job by identifier."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT {_JOB_SELECT} FROM job_queue WHERE id = %s",
+            (job_id,),
+        )
+        row = cur.fetchone()
+    return _row_to_job(row) if row else None
+
+
+def find_job_by_payload(
+    conn,
+    *,
+    job_type: str,
+    payload: Dict[str, Any],
+) -> Job | None:
+    """Return the newest job matching the provided type and payload."""
+
+    serialized_payload = _serialize_payload(payload)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT {_JOB_SELECT}
+            FROM job_queue
+            WHERE job_type = %s AND payload::jsonb = %s::jsonb
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (job_type, serialized_payload),
+        )
+        row = cur.fetchone()
+
+    return _row_to_job(row) if row else None
+
+
+def list_jobs_admin(
+    conn,
+    *,
+    status: str | None = None,
+    job_type: str | None = None,
+    limit: int | None = None,
+    offset: int = 0,
+) -> list[Job]:
+    """Return jobs ordered by priority and id for administrative views."""
+
+    filters: list[str] = []
+    params: list[Any] = []
+
+    if status is not None:
+        filters.append("status = %s")
+        params.append(status)
+
+    if job_type is not None:
+        filters.append("job_type = %s")
+        params.append(job_type)
+
+    sql = f"SELECT {_JOB_SELECT} FROM job_queue"
+    if filters:
+        sql += " WHERE " + " AND ".join(filters)
+    sql += " ORDER BY priority DESC, id DESC"
+
+    if limit is not None:
+        sql += " LIMIT %s"
+        params.append(int(limit))
+    if offset:
+        sql += " OFFSET %s"
+        params.append(int(offset))
+
+    with conn.cursor() as cur:
+        cur.execute(sql, tuple(params))
+        rows = cur.fetchall()
+
+    return [_row_to_job(row) for row in rows]
+
+
 __all__ = [
     "Job",
     "enqueue_job",
@@ -252,4 +406,7 @@ __all__ = [
     "mark_job_done",
     "mark_job_failed",
     "list_jobs",
+    "get_job",
+    "find_job_by_payload",
+    "list_jobs_admin",
 ]

--- a/tests/test_manage_jobs.py
+++ b/tests/test_manage_jobs.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
@@ -43,9 +42,7 @@ def test_jobs_enqueue_summarize_adds_queue_entries(fake_db: FakeDatabase) -> Non
     assert len(rows) == 2
     assert all(row["job_type"] == "summarize" for row in rows)
 
-    payload_episode_ids = {
-        json.loads(row["payload"]).get("episode_id") for row in rows
-    }
+    payload_episode_ids = {row["payload"].get("episode_id") for row in rows}
     assert payload_episode_ids == {1, 2}
 
 


### PR DESCRIPTION
## Summary
- rework the /jobs API to enqueue, list, and fetch jobs through the job_queue service instead of the legacy job table
- expand the job queue service with richer job metadata, lookup helpers, and administrative listing support that mirror the API needs
- update tests, the fake database, and migrations to model the job_queue schema, migrate legacy rows, and drop the obsolete job table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d422fd75c48324873520cc7d5bed25