### PR TITLE
Refine docker workflow for shared server image and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down logs psql
+.PHONY: up down logs psql test
 
 up:
 	cd infra && docker compose up -d
@@ -11,3 +11,6 @@ logs:
 
 psql:
 	docker exec -it podcast_plow_db psql -U postgres -d podcast_plow
+
+test:
+	cd infra && docker compose run --rm ingest pytest -q

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       - db_data:/var/lib/postgresql/data
 
   server:
-    image: python:3.11-slim
+    build:
+      context: ../server
+      dockerfile: Dockerfile
+    image: podcast-plow-server
     container_name: podcast_plow_server
     depends_on:
       - db
@@ -23,23 +26,23 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/podcast_plow
     volumes:
       - ../server:/app
-    command: bash -lc "pip install --no-cache-dir fastapi 'uvicorn[standard]' 'psycopg[binary]' 'pydantic==2.*' python-dotenv feedparser requests lxml sumy youtube-transcript-api && uvicorn app:app --host 0.0.0.0 --port 8000"
     ports:
       - "8000:8000"
 
   ingest:
-    image: python:3.11-slim
+    image: podcast-plow-server
     container_name: podcast_plow_ingest
     depends_on:
       - db
-    working_dir: /app
+    working_dir: /workspace
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/podcast_plow
     volumes:
       - ../server:/app
+      - ..:/workspace
       # mount feeds.txt read-only inside the container at /infra/feeds.txt
       - ./feeds.txt:/infra/feeds.txt:ro
-    command: bash -lc "pip install --no-cache-dir typer feedparser requests lxml 'psycopg[binary]' youtube-transcript-api sumy beautifulsoup4 html5lib readability-lxml && sleep infinity"
+    command: ["sleep", "infinity"]
 
 volumes:
   db_data:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -9,3 +9,4 @@ requests>=2.32,<3.0
 beautifulsoup4>=4.12,<4.13
 lxml>=5.3,<5.4
 sumy>=0.11,<0.12
+pytest>=8.3,<9.0


### PR DESCRIPTION
## Summary
- build the FastAPI service image from the server Dockerfile and reuse it for the ingest worker
- adjust the ingest container mounts/command so the built image can run repo tests
- add pytest as a dependency and a make target that invokes pytest via the ingest service

## Testing
- `docker compose up -d --build` *(fails: docker is not available in the execution environment)*
- `make test` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d42308828883248e95b3df0991b2c2