### PR TITLE
Add episode outline endpoint and ops runbook

### DIFF
--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -1,0 +1,68 @@
+# Operations runbook
+
+This guide explains how to enqueue background work, run processors, and
+inspect the publicly exposed results. All commands assume the repository root
+as the working directory and that `DATABASE_URL` points at your Postgres
+instance (e.g. `postgresql://postgres:postgres@localhost:5432/podcast_plow`).
+
+## Enqueue background jobs
+
+Use the Typer CLI in `server/manage.py` to queue work. Each command accepts a
+comma-separated list of identifiers and an optional priority (higher numbers
+run first).
+
+```bash
+# Summaries for specific episodes
+python -m server.manage jobs enqueue summarize --episode-ids 101,102 --priority 5
+
+# Extract claims for an episode (regenerating transcript chunks first)
+python -m server.manage jobs enqueue extract-claims --episode-ids 101 --refresh
+
+# Re-grade claims that already have evidence
+python -m server.manage jobs enqueue auto-grade --episode-ids 101
+```
+
+## Work the queue
+
+Process queued items with the worker loop. The `--type` flag restricts the job
+kinds a worker will handle. Use `--once` for ad-hoc runs or `--loop` to poll
+continuously.
+
+```bash
+# Process a single summarize job and exit
+python -m server.manage jobs work --once --type summarize
+
+# Long-running worker that handles summarize and extract_claims jobs
+python -m server.manage jobs work --loop --type summarize --type extract_claims --poll-interval 5
+```
+
+## Inspect queue state
+
+List queued, running, failed, or completed jobs:
+
+```bash
+# Show the 10 most recent queued jobs
+python -m server.manage jobs list --status queued --limit 10
+```
+
+When no jobs match, the command prints `No jobs match the provided filters.`
+
+## View public API results
+
+The FastAPI server exposes read-only endpoints once data has been produced:
+
+* `GET /episodes/{id}` – episode metadata, summaries, and graded claims.
+* `GET /episodes/{id}/outline` – ordered outline sections when an outline has
+  been generated for the episode.
+* `GET /topics/{topic}/claims` – all claims tagged with a topic.
+* `GET /claims/{id}` – claim detail with linked evidence and latest grade.
+* `GET /search?q={term}` – lightweight search over episode titles and claims.
+
+Example request:
+
+```bash
+curl http://localhost:8000/episodes/101/outline | jq
+```
+
+Endpoints intentionally omit raw transcript text to keep private uploads out of
+public surfaces.

--- a/tests/fake_db.py
+++ b/tests/fake_db.py
@@ -205,6 +205,7 @@ class FakeDatabase:
             "podcast": [],
             "episode": [],
             "episode_summary": [],
+            "episode_outline": [],
             "claim": [],
             "evidence_source": [],
             "claim_evidence": [],
@@ -219,6 +220,7 @@ class FakeDatabase:
             "podcast": 1,
             "episode": 1,
             "episode_summary": 1,
+            "episode_outline": 1,
             "claim": 1,
             "evidence_source": 1,
             "claim_grade": 1,
@@ -267,6 +269,32 @@ class FakeDatabase:
                 top = summaries[0]
                 return [(top.get("tl_dr"), top.get("narrative"))]
             return []
+
+        if normalized.startswith(
+            "select start_ms, end_ms, heading, bullet_points from episode_outline where episode_id = %s order by start_ms nulls last, id"
+        ):
+            episode_id = params[0]
+            rows = [
+                row
+                for row in self.tables["episode_outline"]
+                if row.get("episode_id") == episode_id
+            ]
+            rows.sort(
+                key=lambda row: (
+                    row.get("start_ms") is None,
+                    row.get("start_ms") if row.get("start_ms") is not None else 0,
+                    row.get("id", 0),
+                )
+            )
+            return [
+                (
+                    row.get("start_ms"),
+                    row.get("end_ms"),
+                    row.get("heading"),
+                    row.get("bullet_points"),
+                )
+                for row in rows
+            ]
 
         if normalized.startswith("delete from episode_summary where episode_id = %s and created_by in (%s, %s)"):
             episode_id, creator_a, creator_b = params


### PR DESCRIPTION
## Summary
- add a FastAPI route at `/episodes/{id}/outline` that returns ordered sections when outline data exists
- parse stored outline bullet text into lists while keeping transcripts private, expanding fake DB helpers and tests
- document job enqueue/work/list commands and public API endpoints in `docs/OPS.md`

## Testing
- pytest tests/test_api_privacy_and_claims.py

------
https://chatgpt.com/codex/tasks/task_e_68d4232e38a083249bdfde49c4f5e9fe