### PR TITLE
Dockerize frontend and add web service

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -29,6 +29,21 @@ services:
     ports:
       - "8000:8000"
 
+  web:
+    build:
+      context: ../web
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost:8000}
+    image: podcast-plow-web
+    container_name: podcast_plow_web
+    depends_on:
+      - server
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost:8000}
+    ports:
+      - "8080:80"
+
   ingest:
     image: podcast-plow-server
     container_name: podcast_plow_ingest

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=20-alpine
+
+FROM node:${NODE_VERSION} AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+
+RUN set -eux; \
+    if [ -f package-lock.json ]; then \
+        npm ci; \
+    elif [ -f pnpm-lock.yaml ]; then \
+        corepack enable; \
+        pnpm install --frozen-lockfile; \
+    elif [ -f yarn.lock ]; then \
+        corepack enable; \
+        yarn install --frozen-lockfile; \
+    else \
+        npm install; \
+    fi
+
+FROM node:${NODE_VERSION} AS build
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build && npm run export
+
+FROM nginx:alpine AS runner
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/out /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /_next/static/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri $uri/ =404;
+    }
+
+    error_page 404 /404.html;
+}


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that exports the Next.js frontend to static assets and serves them from Nginx
- configure an Nginx default server for the exported site
- extend docker-compose with a web service and wire through NEXT_PUBLIC_API_BASE_URL

## Testing
- not run (docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d431504c0483248a4994013c3c7b7e