### PR TITLE
Fix jobs API imports and dedupe queue history

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -2,7 +2,7 @@
 from fastapi import FastAPI, Query
 
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from pydantic import BaseModel
 from starlette.exceptions import HTTPException as StarletteHTTPException


### PR DESCRIPTION
## Summary
- rebuild the jobs API module to clean up imports, normalise request models, and stabilise enqueue/list behaviour
- restore job history recording with psycopg error handling and guard against duplicate queue rows under the fake database used in tests
- import `HTMLResponse` in the FastAPI app so the admin jobs console route loads correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d567071c5483249051d67a01913f23