### PR TITLE
Handle empty link-evidence queue gracefully

### DIFF
--- a/worker/enqueue.py
+++ b/worker/enqueue.py
@@ -76,8 +76,8 @@ def link_evidence(
             )
         )
         if not rows:
-            typer.echo("No claims found for provided filters.")
-            raise typer.Exit(code=1)
+            typer.echo("No claims found for provided filters. Nothing to do.")
+            return
 
         processed = 0
         for claim_id, normalized, raw in rows:


### PR DESCRIPTION
## Summary
- avoid failing the nightly pipeline when no claims match by letting `worker.enqueue link-evidence` exit successfully

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d636b59a28832488f26ad0fd1ae092