### PR TITLE
Add heuristics to discover episode YouTube URLs

### DIFF
--- a/server/ingest/youtube.py
+++ b/server/ingest/youtube.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable, Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from core.db import db_connection
+
+logger = logging.getLogger(__name__)
+
+
+USER_AGENT = "podcast-plow-ingest/0.1"
+YOUTUBE_DOMAINS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+    "www.youtu.be",
+    "youtube-nocookie.com",
+    "www.youtube-nocookie.com",
+}
+
+YOUTUBE_ID_PATTERN = re.compile(
+    r"(?:youtube(?:-nocookie)?\.com/(?:watch\?v=|embed/|shorts/)|youtu\.be/)([A-Za-z0-9_-]{11})"
+)
+
+
+@dataclass
+class EpisodeCandidate:
+    id: int
+    title: str
+    show_notes_url: Optional[str]
+
+
+def normalize_youtube_url(url: str) -> Optional[str]:
+    """Return a canonical watch URL for a YouTube link, if possible."""
+
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+
+    host = parsed.netloc.split(":", 1)[0].lower()
+    if host not in YOUTUBE_DOMAINS:
+        return None
+
+    video_id: Optional[str] = None
+    path = parsed.path or ""
+    query = parse_qs(parsed.query)
+
+    if host.endswith("youtu.be"):
+        slug = path.lstrip("/")
+        if slug:
+            video_id = slug.split("/", 1)[0]
+    elif "/watch" == path:
+        candidates = query.get("v") or []
+        if candidates:
+            video_id = candidates[0]
+    elif "/shorts/" in path:
+        _, _, slug = path.partition("/shorts/")
+        if slug:
+            video_id = slug.split("/", 1)[0]
+    elif "/embed/" in path:
+        _, _, slug = path.partition("/embed/")
+        if slug:
+            video_id = slug.split("/", 1)[0]
+    elif path.startswith("/live/"):
+        video_id = path.split("/", 2)[2] if path.count("/") >= 2 else None
+
+    if not video_id:
+        # Attempt a regex extraction in case the URL contains extra components.
+        match = YOUTUBE_ID_PATTERN.search(url)
+        if match:
+            video_id = match.group(1)
+
+    if not video_id:
+        return None
+
+    video_id = video_id.strip()
+    if not re.fullmatch(r"[A-Za-z0-9_-]{11}", video_id):
+        return None
+
+    return f"https://www.youtube.com/watch?v={video_id}"
+
+
+def _fetch_html(url: str) -> Optional[str]:
+    try:
+        resp = requests.get(url, timeout=20, headers={"User-Agent": USER_AGENT})
+    except requests.RequestException as exc:
+        logger.warning("Failed to download %s: %s", url, exc)
+        return None
+    if resp.status_code >= 400:
+        logger.warning("Non-success status %s for %s", resp.status_code, url)
+        return None
+    resp.encoding = resp.encoding or "utf-8"
+    return resp.text
+
+
+def _extract_candidates_from_soup(soup: BeautifulSoup, base_url: str | None) -> list[str]:
+    candidates: list[str] = []
+
+    def add(url: str | None) -> None:
+        if not url:
+            return
+        candidate_url = url.strip()
+        if not candidate_url:
+            return
+        lowered = candidate_url.lower()
+        if candidate_url.startswith("//"):
+            candidate_url = f"https:{candidate_url}"
+        elif lowered.startswith("youtu.be/") or lowered.startswith("www.youtu.be/"):
+            candidate_url = f"https://{candidate_url}"
+        elif any(
+            lowered.startswith(prefix)
+            for prefix in (
+                "youtube.com/",
+                "www.youtube.com/",
+                "m.youtube.com/",
+                "music.youtube.com/",
+                "youtube-nocookie.com/",
+                "www.youtube-nocookie.com/",
+            )
+        ):
+            candidate_url = f"https://{candidate_url}"
+        elif base_url:
+            candidate_url = urljoin(base_url, candidate_url)
+
+        normalized = normalize_youtube_url(candidate_url)
+        if normalized and normalized not in candidates:
+            candidates.append(normalized)
+
+    for link_tag in soup.find_all("link", attrs={"rel": True, "href": True}):
+        rel_values = link_tag.get("rel")
+        if isinstance(rel_values, (list, tuple)):
+            rels = {value.lower() for value in rel_values if isinstance(value, str)}
+        else:
+            rels = {str(rel_values).lower()}
+        if rels & {"canonical", "alternate"}:
+            add(link_tag.get("href"))
+
+    for meta_name in ("og:video", "og:video:url", "og:video:secure_url", "twitter:player"):
+        tag = soup.find("meta", attrs={"property": meta_name}) or soup.find(
+            "meta", attrs={"name": meta_name}
+        )
+        if tag:
+            add(tag.get("content"))
+
+    for iframe in soup.find_all("iframe"):
+        add(iframe.get("src"))
+
+    for anchor in soup.find_all("a", href=True):
+        add(anchor.get("href"))
+
+    html_text = soup.decode(formatter="html")
+    for match in YOUTUBE_ID_PATTERN.finditer(html_text):
+        slug = match.group(0)
+        add(slug)
+
+    return candidates
+
+
+def _extract_candidates(html: str, base_url: str | None) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    return _extract_candidates_from_soup(soup, base_url)
+
+
+def _episode_candidates(limit: Optional[int]) -> Iterable[EpisodeCandidate]:
+    sql = """
+        SELECT e.id, e.title, e.show_notes_url
+        FROM episode e
+        WHERE e.youtube_url IS NULL
+        ORDER BY e.published_at DESC NULLS LAST, e.id DESC
+    """
+    params: tuple[object, ...] = ()
+    if limit is not None:
+        sql += " LIMIT %s"
+        params = (limit,)
+
+    with db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+
+    for row in rows:
+        yield EpisodeCandidate(*row)
+
+
+def _find_youtube_url(episode: EpisodeCandidate) -> Optional[str]:
+    if episode.show_notes_url:
+        direct = normalize_youtube_url(episode.show_notes_url)
+        if direct:
+            return direct
+
+        html = _fetch_html(episode.show_notes_url)
+        if not html:
+            return None
+
+        candidates = _extract_candidates(html, episode.show_notes_url)
+        if candidates:
+            return candidates[0]
+
+    return None
+
+
+def discover_youtube_urls(limit: Optional[int] = 100) -> int:
+    """Populate missing ``episode.youtube_url`` entries using heuristics."""
+
+    updated = 0
+    for episode in _episode_candidates(limit):
+        candidate = _find_youtube_url(episode)
+        if not candidate:
+            logger.info(
+                "No YouTube match for episode %s — %s", episode.id, episode.title
+            )
+            continue
+
+        with db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE episode SET youtube_url = %s WHERE id = %s", (candidate, episode.id)
+                )
+        logger.info(
+            "Matched YouTube video for episode %s — %s: %s",
+            episode.id,
+            episode.title,
+            candidate,
+        )
+        updated += 1
+
+    return updated
+
+
+__all__ = [
+    "discover_youtube_urls",
+    "normalize_youtube_url",
+]

--- a/server/manage.py
+++ b/server/manage.py
@@ -11,6 +11,7 @@ from db.utils import db_conn
 from ingest import feeds as feeds_module
 from ingest import summaries as summaries_module
 from ingest import transcripts as transcripts_module
+from ingest import youtube as youtube_module
 from services import claims as claims_service
 from services import jobs as jobs_service
 from services import grader as grader_service
@@ -320,6 +321,16 @@ def fetch_transcripts(
 
     inserted = transcripts_module.fetch_transcripts(limit)
     typer.echo(f"Stored transcripts for {inserted} episodes.")
+
+
+@app.command("discover-youtube")
+def discover_youtube(
+    limit: Optional[int] = typer.Option(100, "--limit", "-l", min=1, help="Only scan the most recent N episodes"),
+) -> None:
+    """Populate missing YouTube URLs using show notes heuristics."""
+
+    updated = youtube_module.discover_youtube_urls(limit)
+    typer.echo(f"Found YouTube URLs for {updated} episodes.")
 
 
 @app.command()

--- a/tests/test_youtube_ingest.py
+++ b/tests/test_youtube_ingest.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from server.ingest import youtube
+
+
+def test_normalize_youtube_url_variants() -> None:
+    video_id = "dQw4w9WgXcQ"
+    expected = f"https://www.youtube.com/watch?v={video_id}"
+
+    assert youtube.normalize_youtube_url(f"https://youtu.be/{video_id}") == expected
+    assert (
+        youtube.normalize_youtube_url(
+            f"https://www.youtube.com/watch?v={video_id}&feature=share"
+        )
+        == expected
+    )
+    assert (
+        youtube.normalize_youtube_url(
+            f"https://www.youtube.com/embed/{video_id}?si=z"
+        )
+        == expected
+    )
+    assert (
+        youtube.normalize_youtube_url(
+            f"https://www.youtube.com/shorts/{video_id}?feature=share"
+        )
+        == expected
+    )
+    assert youtube.normalize_youtube_url("https://example.com/video") is None
+
+
+def test_extract_candidates_prefers_canonical_link() -> None:
+    html = """
+    <html>
+      <head>
+        <link rel="canonical" href="https://youtu.be/dQw4w9WgXcQ" />
+        <meta property="og:video" content="https://www.youtube.com/watch?v=AAAAAAAAAAA" />
+      </head>
+      <body>
+        <a href="https://www.youtube.com/watch?v=BBBBBBBBBBB">Video Link</a>
+      </body>
+    </html>
+    """
+
+    candidates = youtube._extract_candidates(html, "https://example.com/post")
+    assert candidates[0] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert "https://www.youtube.com/watch?v=AAAAAAAAAAA" in candidates
+
+
+def test_extract_candidates_from_iframe_and_inline_text() -> None:
+    html = """
+    <html>
+      <body>
+        <iframe src="//www.youtube.com/embed/ZZZZZZZZZZZ"></iframe>
+        <script>
+          const url = "https://youtu.be/XXXXXXXXXXX";
+        </script>
+      </body>
+    </html>
+    """
+
+    candidates = youtube._extract_candidates(html, "https://example.com/notes")
+    assert "https://www.youtube.com/watch?v=ZZZZZZZZZZZ" in candidates
+    assert "https://www.youtube.com/watch?v=XXXXXXXXXXX" in candidates


### PR DESCRIPTION
## Summary
- add a YouTube discovery module that normalizes links and scans show notes for candidate videos
- expose a `discover-youtube` manage command and cover the heuristics with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6cabfb2088324ad0a0ead48a262e1