### PR TITLE
Normalize claim topics and domains

### DIFF
--- a/server/services/claims.py
+++ b/server/services/claims.py
@@ -9,6 +9,7 @@ from typing import Dict, Iterable, List, Sequence
 from worker.claim_extraction import MS_PER_WORD, Claim as ExtractedClaim, extract_claims
 
 from . import chunker
+from .normalization import canonical_domain, canonical_topic
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +44,8 @@ def _adjust_bounds(claim: ExtractedClaim, *, token_start: int) -> ClaimCandidate
     return ClaimCandidate(
         raw_text=claim.raw_text,
         normalized_text=claim.normalized_text.strip(),
-        topic=claim.topic,
-        domain=claim.domain,
+        topic=canonical_topic(claim.topic),
+        domain=canonical_domain(claim.domain),
         risk_level=claim.risk_level,
         start_ms=start,
         end_ms=end,

--- a/server/services/domain_map.json
+++ b/server/services/domain_map.json
@@ -1,0 +1,11 @@
+{
+  "metabolism": ["metabolic", "metabolic health"],
+  "nutrition": ["diet", "dietary", "nutritional science"],
+  "wellness": ["general wellness", "holistic health"],
+  "performance": ["athletic performance", "exercise performance"],
+  "neuro": ["neurology", "brain health", "neuroscience"],
+  "endocrinology": ["endocrine", "hormone health"],
+  "sleep": ["sleep", "sleep health"],
+  "neurochemistry": ["neuro chemistry", "brain chemistry"],
+  "nutrition_support": ["nutritional support"]
+}

--- a/server/services/normalization.py
+++ b/server/services/normalization.py
@@ -1,0 +1,78 @@
+"""Utilities for normalizing claim metadata."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict
+
+
+def _module_path(filename: str) -> Path:
+    return Path(__file__).with_name(filename)
+
+
+def _load_map(filename: str) -> Dict[str, str]:
+    path = _module_path(filename)
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        raw = json.load(handle)
+
+    alias_map: Dict[str, str] = {}
+    for canonical, aliases in raw.items():
+        if canonical is None:
+            continue
+        canonical_clean = str(canonical).strip()
+        if not canonical_clean:
+            continue
+        alias_map[canonical_clean.lower()] = canonical_clean
+        if isinstance(aliases, str):
+            iterable = [aliases]
+        else:
+            iterable = aliases or []
+        for alias in iterable:
+            if not alias:
+                continue
+            alias_clean = str(alias).strip()
+            if not alias_clean:
+                continue
+            alias_map[alias_clean.lower()] = canonical_clean
+    return alias_map
+
+
+@lru_cache(maxsize=1)
+def _topic_map() -> Dict[str, str]:
+    return _load_map("topic_map.json")
+
+
+@lru_cache(maxsize=1)
+def _domain_map() -> Dict[str, str]:
+    return _load_map("domain_map.json")
+
+
+def _canonicalize(value: str | None, lookup: Dict[str, str]) -> str:
+    if value is None:
+        return ""
+    cleaned = value.strip()
+    if not cleaned:
+        return ""
+    canonical = lookup.get(cleaned.lower())
+    if canonical:
+        return canonical
+    return cleaned
+
+
+def canonical_topic(topic: str | None) -> str:
+    """Return the canonical topic label for *topic* if configured."""
+
+    return _canonicalize(topic, _topic_map())
+
+
+def canonical_domain(domain: str | None) -> str:
+    """Return the canonical domain label for *domain* if configured."""
+
+    return _canonicalize(domain, _domain_map())
+
+
+__all__ = ["canonical_topic", "canonical_domain"]

--- a/server/services/topic_map.json
+++ b/server/services/topic_map.json
@@ -1,0 +1,12 @@
+{
+  "ketones": ["ketone", "ketones", "bhb", "beta-hydroxybutyrate"],
+  "intermittent_fasting": ["fasting", "intermittent fasting", "time-restricted eating"],
+  "sleep_quality": ["sleep", "sleep quality", "sleep hygiene"],
+  "general_health": ["general health", "overall health", "health"],
+  "creatine": ["creatine", "creatine monohydrate"],
+  "omega_3": ["omega 3", "omega-3", "fish oil"],
+  "stress_hormones": ["cortisol", "stress"],
+  "gut_microbiome": ["microbiome", "gut health"],
+  "hydration": ["hydration", "fluid balance"],
+  "circadian_rhythm": ["circadian", "circadian rhythm", "body clock"]
+}


### PR DESCRIPTION
## Summary
- add topic and domain synonym maps with helpers to return canonical labels
- normalize claim topics and domains as they are stored and when aggregating topic claims

## Testing
- pytest tests/test_api_privacy_and_claims.py

------
https://chatgpt.com/codex/tasks/task_e_68d6cacaf89c8324afa56a238bf55c57