### PR TITLE
Add job backoff jitter, transcript hash idempotency, and progress reporting

### DIFF
--- a/infra/initdb/002_jobs_and_chunks.sql
+++ b/infra/initdb/002_jobs_and_chunks.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS job_queue (
   status TEXT NOT NULL DEFAULT 'queued',
   priority INT NOT NULL DEFAULT 0,
   run_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  next_run_at TIMESTAMPTZ,
   attempts INT NOT NULL DEFAULT 0,
   max_attempts INT NOT NULL DEFAULT 3,
   last_error TEXT,
@@ -25,15 +26,17 @@ CREATE INDEX IF NOT EXISTS idx_job_queue_status_priority_run_at
 CREATE TABLE IF NOT EXISTS transcript_chunk (
   id SERIAL PRIMARY KEY,
   transcript_id INT REFERENCES transcript(id) ON DELETE CASCADE,
-  start_ms INT,
-  end_ms INT,
-  text TEXT,
-  tokens INT,
-  embedding vector(768)
+  chunk_index INT NOT NULL,
+  token_start INT NOT NULL,
+  token_end INT NOT NULL,
+  token_count INT NOT NULL,
+  text TEXT NOT NULL,
+  key_points JSONB,
+  source_hash TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_transcript_chunk_transcript_id_start_ms
-  ON transcript_chunk (transcript_id, start_ms);
+CREATE INDEX IF NOT EXISTS idx_transcript_chunk_transcript_id_chunk_index
+  ON transcript_chunk (transcript_id, chunk_index);
 
 -- Episode outlines allow summarising sections of an episode
 CREATE TABLE IF NOT EXISTS episode_outline (

--- a/infra/initdb/003_unify_jobs.sql
+++ b/infra/initdb/003_unify_jobs.sql
@@ -29,6 +29,7 @@ $$;
 ALTER TABLE job_queue
     ADD COLUMN IF NOT EXISTS payload JSONB DEFAULT '{}'::jsonb,
     ADD COLUMN IF NOT EXISTS run_at TIMESTAMPTZ DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS next_run_at TIMESTAMPTZ,
     ADD COLUMN IF NOT EXISTS max_attempts INT NOT NULL DEFAULT 3,
     ADD COLUMN IF NOT EXISTS result JSONB,
     ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now(),
@@ -62,6 +63,7 @@ SET
     max_attempts = COALESCE(max_attempts, 3),
     status = COALESCE(status, 'queued'),
     run_at = COALESCE(run_at, created_at, now()),
+    next_run_at = COALESCE(next_run_at, run_at),
     created_at = COALESCE(created_at, now()),
     updated_at = COALESCE(updated_at, created_at, now());
 

--- a/server/api/jobs.py
+++ b/server/api/jobs.py
@@ -71,6 +71,10 @@ class JobResponse(BaseModel):
     created_at: datetime | None = None
     updated_at: datetime | None = None
     priority: int = 0
+    run_at: datetime | None = None
+    next_run_at: datetime | None = None
+    attempts: int = 0
+    max_attempts: int = 0
 
     @field_validator("status", mode="before")
     @classmethod
@@ -95,6 +99,17 @@ class JobResponse(BaseModel):
             return int(value)
         except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
             raise TypeError("priority must be an integer") from exc
+
+    @field_validator("attempts", "max_attempts", mode="before")
+    @classmethod
+    def _coerce_attempts(cls, value: Any) -> int:
+        if value in (None, ""):
+            return 0
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise TypeError("attempts must be numeric") from exc
+        return max(0, parsed)
 
 
 class JobListResponse(BaseModel):
@@ -234,6 +249,10 @@ def _job_to_response(job: jobs_service.Job) -> JobResponse:
         created_at=_normalize_timestamp(job.created_at),
         updated_at=_normalize_timestamp(job.updated_at),
         priority=int(job.priority or 0),
+        run_at=_normalize_timestamp(job.run_at),
+        next_run_at=_normalize_timestamp(job.next_run_at),
+        attempts=int(job.attempts or 0),
+        max_attempts=int(job.max_attempts or 0),
     )
 
 

--- a/server/manage.py
+++ b/server/manage.py
@@ -86,7 +86,23 @@ def _process_job(conn, job: jobs_service.Job) -> None:
         except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
             raise ValueError(f"Invalid episode_id value {episode_id!r}") from exc
         refresh_flag = bool(job.payload.get("refresh", False))
-        summarize_service.summarize_episode(conn, episode_int, refresh=refresh_flag)
+        summarize_service.summarize_episode(
+            conn,
+            episode_int,
+            refresh=refresh_flag,
+            progress_callback=lambda completed, total, chunk: jobs_service.update_job_progress(
+                conn,
+                job.id,
+                total_chunks=total,
+                completed_chunks=completed,
+                current_chunk=None if chunk is None else chunk.chunk_index,
+                message=(
+                    f"Summarizing chunk {completed}/{total}"
+                    if total and completed
+                    else "Summarizing transcript"
+                ),
+            ),
+        )
         return
 
     if job.job_type == "extract_claims":
@@ -98,7 +114,23 @@ def _process_job(conn, job: jobs_service.Job) -> None:
         except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
             raise ValueError(f"Invalid episode_id value {episode_id!r}") from exc
         refresh_flag = bool(job.payload.get("refresh", False))
-        claims_service.extract_episode_claims(conn, episode_int, refresh=refresh_flag)
+        claims_service.extract_episode_claims(
+            conn,
+            episode_int,
+            refresh=refresh_flag,
+            progress_callback=lambda completed, total, chunk: jobs_service.update_job_progress(
+                conn,
+                job.id,
+                total_chunks=total,
+                completed_chunks=completed,
+                current_chunk=None if chunk is None else chunk.chunk_index,
+                message=(
+                    f"Extracting chunk {completed}/{total}"
+                    if total and completed
+                    else "Extracting claims"
+                ),
+            ),
+        )
         return
 
     if job.job_type == "auto_grade":

--- a/server/services/claims.py
+++ b/server/services/claims.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Sequence
+from typing import Callable, Dict, Iterable, List, Sequence
 
 from worker.claim_extraction import MS_PER_WORD, Claim as ExtractedClaim, extract_claims
 
@@ -51,9 +51,13 @@ def _adjust_bounds(claim: ExtractedClaim, *, token_start: int) -> ClaimCandidate
     )
 
 
-def _aggregate_candidates(chunks: Sequence[chunker.ChunkRecord]) -> Dict[str, ClaimCandidate]:
+def _aggregate_candidates(
+    chunks: Sequence[chunker.ChunkRecord],
+    progress_callback: Callable[[int, int, chunker.ChunkRecord], None] | None = None,
+) -> Dict[str, ClaimCandidate]:
     aggregated: Dict[str, ClaimCandidate] = {}
-    for chunk in chunks:
+    total = len(chunks)
+    for index, chunk in enumerate(chunks, start=1):
         chunk_claims = extract_claims(chunk.text)
         for claim in chunk_claims:
             if not claim.normalized_text:
@@ -63,6 +67,8 @@ def _aggregate_candidates(chunks: Sequence[chunker.ChunkRecord]) -> Dict[str, Cl
             existing = aggregated.get(key)
             if existing is None or candidate.start_ms < existing.start_ms:
                 aggregated[key] = candidate
+        if progress_callback is not None:
+            progress_callback(index, total, chunk)
     return aggregated
 
 
@@ -103,6 +109,7 @@ def extract_episode_claims(
     episode_id: int,
     *,
     refresh: bool = False,
+    progress_callback: Callable[[int, int, chunker.ChunkRecord | None], None] | None = None,
 ) -> List[StoredClaim]:
     """Populate deterministic claims for *episode_id*.
 
@@ -113,7 +120,18 @@ def extract_episode_claims(
     if chunk_data is None:
         raise ValueError(f"No transcript available for episode {episode_id}")
 
-    aggregated = _aggregate_candidates(chunk_data.chunks)
+    total_chunks = len(chunk_data.chunks)
+    if progress_callback is not None:
+        progress_callback(0, total_chunks, None)
+
+    aggregated = _aggregate_candidates(
+        chunk_data.chunks,
+        progress_callback=(
+            lambda index, total, chunk: progress_callback(index, total, chunk)
+            if progress_callback is not None
+            else None
+        ),
+    )
     if not aggregated:
         logger.info("No claims detected for episode %s", episode_id)
 

--- a/tests/test_jobs_service_queue.py
+++ b/tests/test_jobs_service_queue.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import datetime as dt
+
+import pytest
+
 from server.services import jobs as jobs_service
 
 from .fake_db import FakeConnection, FakeDatabase
@@ -78,3 +82,69 @@ def test_list_jobs_respects_limit() -> None:
 
     assert len(limited) == 2
     assert [job.priority for job in limited] == [2, 1]
+
+
+def test_enqueue_job_respects_configured_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeDatabase()
+    monkeypatch.setattr(jobs_service, "DEFAULT_MAX_ATTEMPTS", 5)
+
+    with FakeConnection(db) as conn:
+        job = jobs_service.enqueue_job(conn, job_type="alpha")
+
+    assert job.max_attempts == 5
+
+    with FakeConnection(db) as conn:
+        stored = jobs_service.get_job(conn, job.id)
+
+    assert stored is not None
+    assert stored.max_attempts == 5
+
+
+def test_mark_job_failed_applies_jittered_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeDatabase()
+
+    with FakeConnection(db) as conn:
+        jobs_service.enqueue_job(conn, job_type="beta")
+
+    with FakeConnection(db) as conn:
+        job = jobs_service.dequeue_job(conn)
+        assert job is not None
+        monkeypatch.setattr(jobs_service.random, "uniform", lambda low, high: low)
+        before = dt.datetime.now(tz=jobs_service.UTC)
+        jobs_service.mark_job_failed(conn, job, "boom")
+
+    with FakeConnection(db) as conn:
+        refreshed = jobs_service.get_job(conn, job.id)
+
+    assert refreshed is not None
+    assert refreshed.status == "queued"
+    assert refreshed.next_run_at == refreshed.run_at
+    assert refreshed.run_at is not None
+    delay = (refreshed.run_at - before).total_seconds()
+    assert 30 <= delay <= 60
+
+
+def test_update_job_progress_records_payload() -> None:
+    db = FakeDatabase()
+
+    with FakeConnection(db) as conn:
+        job = jobs_service.enqueue_job(conn, job_type="gamma")
+        jobs_service.update_job_progress(
+            conn,
+            job.id,
+            total_chunks=5,
+            completed_chunks=2,
+            current_chunk=1,
+            message="Processing",
+        )
+
+    with FakeConnection(db) as conn:
+        stored = jobs_service.get_job(conn, job.id)
+
+    assert stored is not None
+    assert isinstance(stored.result, dict)
+    assert stored.result["total_chunks"] == 5
+    assert stored.result["completed_chunks"] == 2
+    assert stored.result["current_chunk"] == 1
+    assert stored.result["percent_complete"] == pytest.approx(0.4)
+    assert stored.result.get("message") == "Processing"

--- a/tests/test_manage_jobs.py
+++ b/tests/test_manage_jobs.py
@@ -79,6 +79,9 @@ def test_jobs_work_once_processes_summarize_job(
 
     job_row = fake_db.tables["job_queue"][0]
     assert job_row["status"] == "done"
+    progress = job_row.get("result")
+    assert isinstance(progress, dict)
+    assert progress.get("completed_chunks") == progress.get("total_chunks")
 
     summaries = [row for row in fake_db.tables["episode_summary"] if row["episode_id"] == 1]
     assert summaries, "Expected a summary to be stored for the episode"


### PR DESCRIPTION
## Summary
- add environment-driven defaults, jittered retry backoff, next_run_at tracking, and chunk progress reporting to the job queue
- hash transcripts to keep chunking idempotent and expose next run metadata through the jobs API
- update fake database helpers and tests to cover the new progress, retry, and hashing behavior

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d6cae1055883248578e3bbcbb81d83