### PR TITLE
Add worker service to docker compose

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -66,9 +66,14 @@ services:
     image: podcast-plow-server
     depends_on:
       - db
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/podcast_plow
     command: >
       bash -lc "PYTHONPATH=/app:/workspace:/workspace/server:/workspace/worker
                 python /app/manage.py jobs work --loop"
+    volumes:
+      - ../server:/app
+      - ../worker:/app/worker
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- add a worker service to the docker compose configuration to run the job queue in a loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d905b42ab08324920d5fb8c53d5745