### PR TITLE
Fix Typer CLI compatibility and smoke check

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -102,7 +102,7 @@ SQL
 # Quick health checks
 dc ps
 dc exec -T db psql -U postgres -d podcast_plow -c "SELECT 1;"
-dc exec -T ingest bash -lc "python /app/manage.py --help"
+dc exec -T ingest bash -lc "PYTHONPATH=/app:/workspace:/workspace/server:/workspace/worker python /app/manage.py --help >/dev/null"
 
 # Optionally enqueue one no-op-ish command just to prove command path is OK
 # (Comment out if you prefer not to touch data)


### PR DESCRIPTION
## Summary
- make the CLI modules append the project paths and patch Typer/Click metavar hooks so `--help` works everywhere
- retain compatibility with existing job filters by adding the legacy `--type` alias on the worker command
- teach the smoke test to verify the CLI imports using the same PYTHONPATH as the worker helpers

## Testing
- pytest
- scripts/smoke.sh *(skipped: docker CLI not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9131d4af08324acd42e863182a9a2